### PR TITLE
Add proper UMLS release date when creating new UMLS submissions.

### DIFF
--- a/bin/create_umls_submissions.rb
+++ b/bin/create_umls_submissions.rb
@@ -22,7 +22,11 @@ puts "Running on #{platform} platform"
 
 umls_files_path = "/srv/ncbo/share/scratch/umls2rdf/output"
 umls_files = Dir.glob(File.join(umls_files_path, "*.ttl"))
-new_version = "2014AB"
+
+# UMLS Release Details.  Update this for new release
+new_version = "2017AB"
+new_released = "2017-05-09" #Release date
+
 file_index = {}
 umls_files.each do |x|
   if not x["semantictypes"].nil?
@@ -61,6 +65,6 @@ new_submissions.each_key do |acr|
   ont, sub, file = new_submissions[acr]
   filename = file.split("/")[-1]
   pull.create_submission(ont,sub,file,filename,logger=nil,
-                         add_to_pull=false,new_version)
+                         add_to_pull=false,new_version,new_released)
   puts "Created new submission for #{acr}"
 end

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -105,7 +105,7 @@ module NcboCron
           new_sub.version = new_version
         end
 	unless new_released.nil?
-          new.sub.released = DateTime.now
+          new_sub.released = DateTime.now
 	end
         new_sub.submissionStatus = nil
         new_sub.creationDate = nil

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -88,7 +88,7 @@ module NcboCron
       end
 
       def create_submission(ont, sub, file, filename, logger=nil,
-                            add_to_pull=true,new_version=nil)
+			    add_to_pull=true,new_version=nil,new_released=nil)
         logger ||= Kernel.const_defined?("LOGGER") ? Kernel.const_get("LOGGER") : Logger.new(STDOUT)
         new_sub = LinkedData::Models::OntologySubmission.new
 
@@ -104,9 +104,11 @@ module NcboCron
         unless new_version.nil?
           new_sub.version = new_version
         end
+	unless new_released.nil?
+          new.sub.released = DateTime.now
+	end
         new_sub.submissionStatus = nil
         new_sub.creationDate = nil
-        new_sub.released = DateTime.now
         new_sub.missingImports = nil
         new_sub.metrics = nil
 


### PR DESCRIPTION
create_new_umls_ontology script doesn't have a way to add correct release date. 
When feature adds correct release date for new UMLS submissions 