### PR TITLE
Flush zombie graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# ncbo_cron
+
+## Run the ncbo_cron daemon
+
+To run it use the `bin/ncbo_cron` command
+
+Running this command without option will cause to run the jobs according to the settings defined in the NcboCron config file. Or by default in [ncbo_cron/lib/ncbo_cron/config.rb](https://github.com/ncbo/ncbo_cron/blob/master/lib/ncbo_cron/config.rb)
+
+But the user can define options to change some settings.
+Example to run the flush old graph job every 3 hours and to disable the automatic pull of new submissions
+
+```
+bin/ncbo_cron --flush-old-graphs "0 */3 * * *" --disable-pull
+```
+
+It will run by default as a daemon
+
+But it will not run as a daemon if you use one of the following options:
+
+* console (to open a pry console
+* view_queue (view the queue of jobs waiting for processing)
+* queue_submission (adding a submission to the processing submission queue)
+* kill (stop the ncbo_cron daemon)
+
+## Stop the ncbo_cron daemon
+
+The PID of the ncbo_cron process is in /var/run/ncbo_cron/ncbo_cron.pid
+
+To stop the ncbo_cron daemon: 
+```
+bin/ncbo_cron -k
+```

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 To run it use the `bin/ncbo_cron` command
 
-Running this command without option will cause to run the jobs according to the settings defined in the NcboCron config file. Or by default in [ncbo_cron/lib/ncbo_cron/config.rb](https://github.com/ncbo/ncbo_cron/blob/master/lib/ncbo_cron/config.rb)
+Running this command without option will run the job according to the settings defined in the NcboCron config file. Or by default in [ncbo_cron/lib/ncbo_cron/config.rb](https://github.com/ncbo/ncbo_cron/blob/master/lib/ncbo_cron/config.rb)
 
-But the user can define options to change some settings.
-Example to run the flush old graph job every 3 hours and to disable the automatic pull of new submissions
+But the user can add arguments to change some settings.
+
+Here an example to run the flush old graph job every 3 hours and to disable the automatic pull of new submissions:
 
 ```
 bin/ncbo_cron --flush-old-graphs "0 */3 * * *" --disable-pull
@@ -17,7 +18,7 @@ It will run by default as a daemon
 
 But it will not run as a daemon if you use one of the following options:
 
-* console (to open a pry console
+* console (to open a pry console)
 * view_queue (view the queue of jobs waiting for processing)
 * queue_submission (adding a submission to the processing submission queue)
 * kill (stop the ncbo_cron daemon)

--- a/bin/ncbo_cron
+++ b/bin/ncbo_cron
@@ -123,6 +123,9 @@ opt_parser = OptionParser.new do |opts|
   opts.on("-f", "--flush-old-graphs SCHED", String, "cron schedule to delete class graphs of archive submissions", "(default: #{options[:cron_flush]})") do |c|
     options[:cron_flush] = c
   end
+  opts.on("--remove-zombie-graphs", "flush class graphs from deleted ontologies") do |v|
+    options[:remove_zombie_graphs] = true
+  end
   opts.on("-w", "--warm-long-queries SCHED", String, "cron schedule to warmup long time running queries", "(default: #{options[:cron_warmq]})") do |c|
     options[:cron_warmq] = c
   end  

--- a/bin/ncbo_cron
+++ b/bin/ncbo_cron
@@ -289,7 +289,7 @@ runner.execute do |opts|
         logger.info "Logging flush details to #{flush_log_path}"; logger.flush
         t0 = Time.now
         parser = NcboCron::Models::OntologySubmissionParser.new
-        flush_onts = parser.process_flush_classes(flush_logger)
+        flush_onts = parser.process_flush_classes(flush_logger, flush_options[:remove_zombie_graphs])
         logger.info "Flushed #{flush_onts.length} submissions in #{Time.now - t0} sec."; logger.flush
         logger.info "Finished flush"; logger.flush
       end

--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -32,15 +32,21 @@ Annotator.config do |config|
 end
 
 NcboCron.config do |config|
+  # see https://github.com/ncbo/ncbo_cron/blob/master/lib/ncbo_cron/config.rb for default config
   config.redis_host  ||= "localhost"
   config.redis_port  ||= 6379
   config.search_index_all_url = "http://localhost:8983/solr/term_search_core2"
   config.property_search_index_all_url = "http://localhost:8983/solr/prop_search_core2"
 
   # Ontologies Report config
+  config.enable_ontologies_report  = true
   config.ontology_report_path = "./test/reports/ontologies_report.json"
 
+  # Remove graphs from deleted ontologies when running process_flush_classes
+  config.remove_zombie_graphs      = false
+
   # Google Analytics config
+  config.enable_ontology_analytics = false
   config.analytics_service_account_email_address = "123456789999-sikipho0wk8q0atflrmw62dj4kpwoj3c@developer.gserviceaccount.com"
   config.analytics_path_to_key_file              = "config/bioportal-analytics.p12"
   config.analytics_profile_id                    = "ga:1234567"

--- a/lib/ncbo_cron/config.rb
+++ b/lib/ncbo_cron/config.rb
@@ -28,6 +28,8 @@ module NcboCron
     @settings.enable_processing ||= true
     @settings.enable_pull ||= true
     @settings.enable_flush ||= true
+    # Don't remove graphs from deleted ontologies by default when flushing classes
+    @settings.remove_zombie_graphs ||= false
     @settings.enable_warmq ||= true
     @settings.enable_mapping_counts ||= true
     # enable ontology analytics


### PR DESCRIPTION
re-creating original pull request #1; since remote branch was removed

Add a README.md file
And the possibility to flush "zombie graphs" (class graphs from the submission that have been deleted) when the flush_class_graphs CRON job is run