### PR TITLE
Add a script to pull a new version of an ontology on demand

### DIFF
--- a/bin/ncbo_ontology_pull
+++ b/bin/ncbo_ontology_pull
@@ -1,0 +1,46 @@
+#!/usr/bin/env ruby
+
+$0 = "ncbo_cron"
+
+# Exit cleanly from an early interrupt
+Signal.trap("INT") { exit 1 }
+
+# Setup the bundled gems in our environment
+require 'bundler/setup'
+# redis store for looking up queued jobs
+require 'redis'
+
+require_relative '../lib/ncbo_cron'
+require_relative '../config/config'
+require 'optparse'
+
+ontology_acronym = ''
+opt_parser = OptionParser.new do |opts|
+  opts.on('-o', '--ontology ACRONYM', 'Ontology acronym to pull if new version exist') do |acronym|
+    ontology_acronym = acronym
+  end
+
+  # Display the help screen, all programs are assumed to have this option.
+  opts.on( '-h', '--help', 'Display this screen') do
+    puts opts
+    exit
+  end
+end
+opt_parser.parse!
+
+logger = Logger.new($stdout)
+logger.info "Starting ncbo pull"; logger.flush
+puller = NcboCron::Models::OntologyPull.new
+begin
+  puller.do_ontology_pull(ontology_acronym, logger: logger , enable_pull_umls:true )
+rescue NcboCron::Models::OntologyPull::RemoteFileException => e
+  logger.error "RemoteFileException: No submission file at pull location #{last.pullLocation.to_s} for ontology #{ont.acronym}."
+  logger.flush
+rescue StandardError => e
+  e.backtrace
+  logger.error e.message
+  logger.flush
+end
+logger.info "Finished ncbo pull"; logger.flush
+
+

--- a/bin/ncbo_ontology_pull
+++ b/bin/ncbo_ontology_pull
@@ -33,11 +33,7 @@ logger.info "Starting ncbo pull"; logger.flush
 puller = NcboCron::Models::OntologyPull.new
 begin
   puller.do_ontology_pull(ontology_acronym, logger: logger , enable_pull_umls:true )
-rescue NcboCron::Models::OntologyPull::RemoteFileException => e
-  logger.error "RemoteFileException: No submission file at pull location #{last.pullLocation.to_s} for ontology #{ont.acronym}."
-  logger.flush
 rescue StandardError => e
-  e.backtrace
   logger.error e.message
   logger.flush
 end

--- a/bin/ncbo_ontology_pull
+++ b/bin/ncbo_ontology_pull
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$0 = "ncbo_cron"
+$0 = "ncbo_ontology_pull"
 
 # Exit cleanly from an early interrupt
 Signal.trap("INT") { exit 1 }

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -8,10 +8,14 @@ module NcboCron
     class OntologyPull
 
       class RemoteFileException < StandardError
+        attr_reader :submission
+
+        def initialize(submission)
+          super
+          @submission = submission
+        end
       end
 
-      def initialize()
-      end
 
       def do_remote_ontology_pull(options = {})
         logger = options[:logger] || Logger.new($stdout)

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -38,7 +38,7 @@ module NcboCron
             next if last.pullLocation.nil?
             last.bring(:uploadFilePath) if last.bring?(:uploadFilePath)
 
-            if last.hasOntologyLanguage.umls? && umls_download_url
+            if last.hasOntologyLanguage.umls? && !umls_download_url.empty?
               last.pullLocation= RDF::URI.new(umls_download_url + last.pullLocation.split("/")[-1])
               logger.info("Using alternative download for umls #{last.pullLocation.to_s}")
               logger.flush
@@ -66,7 +66,6 @@ module NcboCron
                 logger.flush()
                 new_submissions << create_submission(ont, last, file, filename, logger)
               end
-
               file.close
             else
               begin

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -27,7 +27,7 @@ module NcboCron
         ontologies.select! { |ont| ont_to_include.include?(ont.acronym) } unless ont_to_include.empty?
         enable_pull_umls = options[:enable_pull_umls]
         umls_download_url = options[:pull_umls_url]
-        ontologies.sort! {|a, b| a.acronym.downcase <=> b.acronym.downcase}
+        ontologies.sort! { |a, b| a.acronym.downcase <=> b.acronym.downcase }
         new_submissions = []
 
         ontologies.each do |ont|
@@ -115,7 +115,7 @@ module NcboCron
         last.bring(:uploadFilePath) if last.bring?(:uploadFilePath)
 
         if last.hasOntologyLanguage.umls? && umls_download_url
-          last.pullLocation= RDF::URI.new(umls_download_url + last.pullLocation.split("/")[-1])
+          last.pullLocation = RDF::URI.new(umls_download_url + last.pullLocation.split("/")[-1])
           logger.info("Using alternative download for umls #{last.pullLocation.to_s}")
           logger.flush
         end
@@ -142,8 +142,8 @@ module NcboCron
         end
       end
 
-      def create_submission(ont, sub, file, filename, logger=nil,
-        add_to_pull=true,new_version=nil,new_released=nil)
+      def create_submission(ont, sub, file, filename, logger = nil,
+                            add_to_pull = true, new_version = nil, new_released = nil)
         logger ||= Kernel.const_defined?("LOGGER") ? Kernel.const_get("LOGGER") : Logger.new(STDOUT)
         new_sub = LinkedData::Models::OntologySubmission.new
 
@@ -172,9 +172,9 @@ module NcboCron
 
         # check if OWLAPI is able to parse the file before creating a new submission
         owlapi = LinkedData::Parser::OWLAPICommand.new(
-            full_file_path,
-            File.expand_path(new_sub.data_folder.to_s),
-            logger: logger)
+          full_file_path,
+          File.expand_path(new_sub.data_folder.to_s),
+          logger: logger)
         owlapi.disable_reasoner
         parsable = true
 
@@ -193,7 +193,7 @@ module NcboCron
 
             if add_to_pull
               submission_queue = NcboCron::Models::OntologySubmissionParser.new
-              submission_queue.queue_submission(new_sub, {all: true})
+              submission_queue.queue_submission(new_sub, { all: true })
               logger.info("OntologyPull created a new submission (#{submission_id}) for ontology #{ont.acronym}")
             end
           else

--- a/test/test_ontology_pull.rb
+++ b/test/test_ontology_pull.rb
@@ -41,14 +41,14 @@ class TestOntologyPull < TestCase
     @@redis.del NcboCron::Models::OntologySubmissionParser::QUEUE_HOLDER
   end
 
-  def test_remote_ontology_pull()
+  def test_remote_ontology_pull
     ontologies = init_ontologies(1)
     ont = LinkedData::Models::Ontology.find(ontologies[0].id).first
     ont.bring(:submissions) if ont.bring?(:submissions)
     assert_equal 1, ont.submissions.length
 
     pull = NcboCron::Models::OntologyPull.new
-    pull.do_remote_ontology_pull()
+    pull.do_remote_ontology_pull
 
     # check that the pull creates a new submission when the file has changed
     ont = LinkedData::Models::Ontology.find(ontologies[0].id).first
@@ -72,7 +72,7 @@ class TestOntologyPull < TestCase
     ont = LinkedData::Models::Ontology.find(ontologies[0].id).first
     ont.bring(:submissions) if ont.bring?(:submissions)
     assert_equal 2, ont.submissions.length
-    pull.do_remote_ontology_pull()
+    pull.do_remote_ontology_pull
     assert_equal 2, ont.submissions.length
   end
 
@@ -172,7 +172,7 @@ class TestOntologyPull < TestCase
       sub.pullLocation = RDF::IRI.new(@@url)
       sub.save() rescue binding.pry
     end
-    return ontologies
+    ontologies
   end
 
 end


### PR DESCRIPTION
### Issue
There is only one where the testing if a new file exists, is in the [pull_location CRON job ](https://github.com/ontoportal-lirmm/ncbo_cron/blob/master/bin/ncbo_cron#L273). Which is done once a day.

The problem is that if we do an ontology reprocess with the ncbo_ontolgy_process script, it will not test the existence of a new version.

### The solutions 

There are two ways to solve this

1. The first and simple one is to just add a script called ncbo_ontology_pull to do the pull on demand.
2. The second more complex is to add in the submission process workflow a step that comes before the generate_rdf step called do_pull_location that will download and create a new submission if a new version is found.

**This PR is the implementation of the first proposition.**

### How to use 
```
Usage: ncbo_ontology_pull [options]
    -o, --ontology ACRONYM           Ontology acronym to pull if new version exist
    -h, --help                       Display this screen
```
