### PR TITLE
Fix the OBO Foundry synchronization script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ config/*.p12
 config/*.json
 data/
 projectFilesBackup/
+.bundle
 .ruby-version
 repo*
 *.turtle

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'faraday', '~> 2'
+gem 'faraday-follow_redirects', '~> 0'
 gem 'ffi'
 
 # This is needed temporarily to pull the Google Universal Analytics (UA)

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'faraday', '~> 2'
-gem 'faraday-follow_redirects', '~> 0'
 gem 'ffi'
 
 # This is needed temporarily to pull the Google Universal Analytics (UA)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ PATH
   specs:
     ncbo_cron (0.0.1)
       dante
+      faraday (~> 2)
+      faraday-follow_redirects (~> 0)
       goo
       google-analytics-data
       mlanett-redis-lock
@@ -94,12 +96,13 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
-    faraday (2.9.0)
-      faraday-net_http (>= 2.0, < 3.2)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.1.0)
-      net-http
+    faraday-net_http (3.0.2)
     faraday-retry (2.2.1)
       faraday (~> 2.0)
     ffi (1.16.3)
@@ -185,8 +188,6 @@ GEM
     mlanett-redis-lock (0.2.7)
       redis
     multi_json (1.15.0)
-    net-http (0.4.1)
-      uri
     net-http-persistent (2.9.4)
     net-imap (0.4.10)
       date
@@ -237,6 +238,7 @@ GEM
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     ruby-xxHash (0.4.0.2)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
@@ -264,7 +266,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uri (0.13.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
     webrick (1.8.1)
@@ -276,8 +277,6 @@ PLATFORMS
 DEPENDENCIES
   cube-ruby
   email_spec
-  faraday (~> 2)
-  faraday-follow_redirects (~> 0)
   ffi
   goo!
   google-analytics-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.0.2)
     faraday-retry (2.2.1)
       faraday (~> 2.0)
@@ -273,6 +275,8 @@ PLATFORMS
 DEPENDENCIES
   cube-ruby
   email_spec
+  faraday (~> 2)
+  faraday-follow_redirects (~> 0)
   ffi
   goo!
   google-analytics-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,13 +94,12 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (~> 2.1)
       mail (~> 2.7)
-    faraday (2.8.1)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.0.2)
+    faraday-net_http (3.1.0)
+      net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
     ffi (1.16.3)
@@ -186,6 +185,8 @@ GEM
     mlanett-redis-lock (0.2.7)
       redis
     multi_json (1.15.0)
+    net-http (0.4.1)
+      uri
     net-http-persistent (2.9.4)
     net-imap (0.4.10)
       date
@@ -236,7 +237,6 @@ GEM
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     ruby-xxHash (0.4.0.2)
-    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     rufus-scheduler (2.0.24)
       tzinfo (>= 0.3.22)
@@ -264,6 +264,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
+    uri (0.13.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
     webrick (1.8.1)

--- a/ncbo_cron.gemspec
+++ b/ncbo_cron.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("dante")
+  gem.add_dependency('faraday', '~> 2')
+  gem.add_dependency('faraday-follow_redirects', '~> 0')
   gem.add_dependency("goo")
   gem.add_dependency("google-analytics-data")
   gem.add_dependency("mlanett-redis-lock")


### PR DESCRIPTION
Our OBO Foundry synchronization script has been erring out with a `JSON::ParserError`. This pull request eliminates the use of GitHub GraphQL queries to fetch files form GitHub in favor of using simple HTTP requests. It also adds the `faraday` and `faraday-follow_redirects` gems to the gemspec file.

Resolves #78 