### PR TITLE
Rename logs directory to log for consistency with standard layout

### DIFF
--- a/lib/ncbo_cron/config.rb
+++ b/lib/ncbo_cron/config.rb
@@ -99,7 +99,7 @@ module NcboCron
     yield @settings if block_given?
 
     # ── choose defaults *after* user input ───────────────────────────────
-    @settings.log_dir  ||= File.expand_path("logs", Dir.pwd)
+    @settings.log_dir  ||= File.expand_path("log", Dir.pwd)
     @settings.log_path ||= File.join(@settings.log_dir, "scheduler.log")
     @settings.pid_path ||= File.expand_path("ncbo_cron.pid", Dir.pwd)
 


### PR DESCRIPTION
- Renamed default log directory from 'logs' to 'log'
- Aligns with common Ruby/Rails conventions (e.g., log/scheduler.log)
- Helps reduce confusion across components like ontologies_api which already use 'log'
- Does not affect behavior if log_dir is explicitly set in config