### PR TITLE
Handle ontologies with missing pullLocation gracefully in pull job

### DIFF
--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -21,23 +21,28 @@ module NcboCron
 
         ontologies.each do |ont|
           begin
-            begin
-              new_submissions << NcboCron::Helpers::OntologyHelper.do_ontology_pull(ont.acronym,
-                                                       enable_pull_umls: enable_pull_umls,
-                                                       umls_download_url: umls_download_url,
-                                                       logger: logger, add_to_queue: true)
-            rescue NcboCron::Helpers::OntologyHelper::RemoteFileException => error
-              logger.info "RemoteFileException: No submission file at pull location #{error.submission.pullLocation.to_s} for ontology #{ont.acronym}."
-              logger.flush
-              LinkedData::Utils::Notifications.remote_ontology_pull(error.submission)
-            end
+            new_submissions << NcboCron::Helpers::OntologyHelper.do_ontology_pull(
+              ont.acronym,
+              enable_pull_umls: enable_pull_umls,
+              umls_download_url: umls_download_url,
+              logger: logger,
+              add_to_queue: true
+            )
+          rescue NcboCron::Helpers::OntologyHelper::RemoteFileException => e
+            logger.warn(e.message)
+            # logger.warn("RemoteFileException: No submission file at pull location #{e.submission.pullLocation} for ontology #{ont.acronym}.")
+            logger.flush
+            LinkedData::Utils::Notifications.remote_ontology_pull(e.submission)
+          rescue NcboCron::Helpers::OntologyHelper::MissingPullLocationException => e
+            logger.warn("Skipping #{e.acronym}: no pullLocation defined.")
+            logger.flush
+          rescue StandardError => e
+            logger.error("Unexpected error during pull of #{ont.acronym}: #{e.class} - #{e.message}")
+            logger.flush
+            # Optional: you can uncomment this for local debugging
+            # logger.debug(e.backtrace.join("\n\t"))
           end
-        rescue Exception => e
-          logger.error "Problem retrieving #{ont.acronym} in OntologyPull:\n" + e.message + "\n" + e.backtrace.join("\n\t")
-          logger.flush()
-          next
         end
-
         if options[:cache_clear] == true
           logger.info('Clearing Goo/HTTP caches...')
           redis_goo.flushdb


### PR DESCRIPTION
Raise MissingPullLocationException when an ontology has no pullLocation set, and catch it in the ontology pull loop to avoid logging a full stack trace. Log a concise warning instead.

Resolves https://github.com/ncbo/ncbo_cron/issues/68