### PR TITLE
remove executable directives and add development dependencies

### DIFF
--- a/ncbo_cron.gemspec
+++ b/ncbo_cron.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/ncbo/ncbo_cron"
 
   gem.files         = Dir['**/*']
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  # gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "ncbo_cron"
   gem.require_paths = ["lib"]
@@ -25,4 +25,15 @@ Gem::Specification.new do |gem|
   gem.add_dependency("ontologies_linked_data")
   gem.add_dependency("redis")
   gem.add_dependency("rufus-scheduler", "~> 2.0.24")
+
+  gem.add_development_dependency "rubocop"
+  gem.add_development_dependency "simplecov"
+  gem.add_development_dependency "email_spec"
+  gem.add_development_dependency "minitest", '~> 5.2'
+  gem.add_development_dependency "minitest-hooks", "~> 1.5"
+  gem.add_development_dependency "minitest-reporters", "~> 1.7"
+  gem.add_development_dependency "mocha", "~> 2.7"
+  gem.add_development_dependency "simplecov-cobertura"
+  gem.add_development_dependency "webmock", "~> 3.25"
+  gem.add_development_dependency "webrick"
 end


### PR DESCRIPTION
Remove executable specification from gemspec.  Scripts in the bin directory are not intended to be executables when this gem is included as a dependency