### PR TITLE
Refactor/remove unused umls pull feature

### DIFF
--- a/bin/ncbo_cron
+++ b/bin/ncbo_cron
@@ -94,9 +94,6 @@ opt_parser = OptionParser.new do |opts|
   opts.on("--disable-mapping-counts", "disable mapping counts creation") do |v|
     options[:enable_mapping_counts] = false
   end
-  opts.on("--enable-umls", "enable UMLS auto-pull") do |v|
-    options[:enable_pull_umls] = true
-  end
   opts.on("--disable-ontology-analytics", "disable ontology analytics refresh", "(default: #{options[:enable_ontology_analytics]})") do |v|
     options[:enable_ontology_analytics] = false
   end
@@ -120,9 +117,6 @@ opt_parser = OptionParser.new do |opts|
   end
   opts.on("--disable-obofoundry_sync", "disable OBO Foundry synchronization report", "(default: #{options[:enable_obofoundry_sync]})") do |v|
     options[:enable_obofoundry_sync] = false
-  end
-  opts.on("--pull-umls-url URL", "set UMLS pull location") do |v|
-    options[:pull_umls_url] = v
   end
   opts.on("-c", "--pull-cron SCHED", String, "cron schedule for ontology pull", "(default: #{options[:pull_schedule]})") do |c|
     options[:pull_schedule] = c
@@ -289,7 +283,6 @@ runner.execute do |opts|
         logger.info "Logging pull details to #{pull_log_path}"; logger.flush
         puller = NcboCron::Models::OntologyPull.new
         pulled_onts = puller.do_remote_ontology_pull(logger: pull_logger,
-                                                     enable_pull_umls: options[:enable_pull_umls],
                                                      cache_clear: true)
         logger.info "Finished ncbo pull"; logger.flush
         logger.info "Pull summary:\n#{pulled_onts.map {|o| o.id.to_s}}"

--- a/lib/ncbo_cron/config.rb
+++ b/lib/ncbo_cron/config.rb
@@ -44,9 +44,6 @@ module NcboCron
     # enable mgrep dictionary generation job
     @settings.enable_dictionary_generation_cron_job ||= false
 
-    # UMLS auto-pull
-    @settings.pull_umls_url ||= ""
-    @settings.enable_pull_umls ||= false
     @settings.enable_obofoundry_sync ||= true
 
     # Schedulues

--- a/lib/ncbo_cron/ontology_pull.rb
+++ b/lib/ncbo_cron/ontology_pull.rb
@@ -3,26 +3,19 @@ require_relative 'ontology_helper'
 
 module NcboCron
   module Models
-
     class OntologyPull
-
       def do_remote_ontology_pull(options = {})
         logger = options[:logger] || Logger.new($stdout)
-        logger.info "UMLS auto-pull #{options[:enable_pull_umls] == true}"
         logger.flush
         ontologies = LinkedData::Models::Ontology.where.include(:acronym).all
         ont_to_include = []
         ontologies.select! { |ont| ont_to_include.include?(ont.acronym) } unless ont_to_include.empty?
-        enable_pull_umls = options[:enable_pull_umls]
-        umls_download_url = options[:pull_umls_url]
         ontologies.sort! { |a, b| a.acronym.downcase <=> b.acronym.downcase }
         new_submissions = []
 
         ontologies.each do |ont|
           sub = NcboCron::Helpers::OntologyHelper.do_ontology_pull(
             ont.acronym,
-            enable_pull_umls: enable_pull_umls,
-            umls_download_url: umls_download_url,
             logger: logger,
             add_to_queue: true
           )

--- a/lib/ncbo_cron/ontology_submission_parser.rb
+++ b/lib/ncbo_cron/ontology_submission_parser.rb
@@ -33,8 +33,8 @@ module NcboCron
           # processing the remaining actions on the new submission
           if actions.key?(:remote_pull) && actions[:remote_pull]
             acronym = NcboCron::Helpers::OntologyHelper.acronym_from_submission_id(realKey)
-            new_submission = NcboCron::Helpers::OntologyHelper.do_ontology_pull(acronym, enable_pull_umls: false,
-                                                                                umls_download_url: '', logger: logger,
+            new_submission = NcboCron::Helpers::OntologyHelper.do_ontology_pull(acronym,
+                                                                                logger: logger,
                                                                                 add_to_queue: false)
             return unless new_submission
             realKey = new_submission.id.to_s


### PR DESCRIPTION
This PR removes the unused mechanism in ncbo_cron for specifying a custom pull location for UMLS ontologies. The feature has not been used in a long time, and the standard remote pull mechanism can be used if needed.