### PR TITLE
Run OntologyRank independently; fix analytics visit count issue

### DIFF
--- a/bin/ncbo_cron
+++ b/bin/ncbo_cron
@@ -103,6 +103,9 @@ opt_parser = OptionParser.new do |opts|
   opts.on("--disable-cloudflare-analytics", "disable Cloudflare analytics job", "(default: #{options[:enable_cloudflare_analytics]})") do |v|
     options[:enable_cloudflare_analytics] = false
   end
+  opts.on("--disable-ontology-rank", "disable ontology rank generation", "(default: #{options[:enable_ontology_rank]})") do |v|
+    options[:enable_ontology_rank] = false
+  end
   opts.on("--disable-ontologies-report", "disable ontologies report generation", "(default: #{options[:enable_ontologies_report]})") do |v|
     options[:enable_ontologies_report] = false
   end
@@ -141,6 +144,9 @@ opt_parser = OptionParser.new do |opts|
   end
   opts.on("--ontology-analytics SCHED", String, "cron schedule to run ontology analytics refresh", "(default: #{options[:cron_ontology_analytics]})") do |c|
     options[:cron_ontology_analytics] = c
+  end
+  opts.on("--ontology-rank SCHED", String, "cron schedule to generate ontology rankings", "(default: #{options[:cron_ontology_rank]})") do |c|
+    options[:cron_ontology_rank] = c
   end
   opts.on("--ontologies-report SCHED", String, "cron schedule to run ontologies report generation", "(default: #{options[:cron_ontologies_report]})") do |c|
     options[:cron_ontologies_report] = c
@@ -377,8 +383,6 @@ runner.execute do |opts|
         t0 = Time.now
         # Generate ontology analytics
         NcboCron::Models::OntologyAnalytics.new(ontology_analytics_logger).run
-        # Generate ontology ranking
-        NcboCron::Models::OntologyRank.new(ontology_analytics_logger).run
         logger.info "Ontology analytics refresh job completed in #{Time.now - t0} sec."; logger.flush
         logger.info "Finished ontology analytics refresh"; logger.flush
       end
@@ -401,6 +405,26 @@ runner.execute do |opts|
         NcboCron::Models::CloudflareAnalytics.new(cloudflare_analytics_logger).run
         logger.info "Cloudflare analytics job completed in #{Time.now - t0} sec."; logger.flush
         logger.info 'Finished Cloudflare analytics job'; logger.flush
+      end
+    end
+  end
+
+  if options[:enable_ontology_rank]
+    ontology_rank_thread = Thread.new do
+      ontology_rank_options = options.dup
+      ontology_rank_options[:job_name] = "ncbo_cron_ontology_rank"
+      ontology_rank_options[:scheduler_type] = :cron
+      ontology_rank_options[:cron_schedule] = ontology_rank_options[:cron_ontology_rank]
+      logger.info "Setting up ontology rank generation job with #{ontology_rank_options[:cron_ontology_rank]}"; logger.flush
+      ontology_rank_log_path = File.join(log_path, "#{log_filename_noExt}-ontology-rank.log")
+      ontology_rank_logger = Logger.new(ontology_rank_log_path)
+      NcboCron::Scheduler.scheduled_locking_job(ontology_rank_options) do
+        logger.info "Starting ontology rank generation job"; logger.flush
+        logger.info "Logging ontology rank generation details to #{ontology_rank_log_path}"; logger.flush
+        t0 = Time.now
+        NcboCron::Models::OntologyRank.new(ontology_rank_logger).run
+        logger.info "Ontology rank generation job completed in #{Time.now - t0} sec."; logger.flush
+        logger.info "Finished ontology rank generation job"; logger.flush
       end
     end
   end
@@ -542,6 +566,7 @@ runner.execute do |opts|
   warmq_thread.join if warmq_thread
   analytics_thread.join if analytics_thread
   cloudflare_analytics_thread.join if cloudflare_analytics_thread
+  ontology_rank_thread.join if ontology_rank_thread
   ontologies_report_thread.join if ontologies_report_thread
   index_synchronizer_thread.join if index_synchronizer_thread
   spam_deletion_thread.join if spam_deletion_thread

--- a/lib/ncbo_cron/config.rb
+++ b/lib/ncbo_cron/config.rb
@@ -33,6 +33,8 @@ module NcboCron
     @settings.enable_ontology_analytics ||= true
     # enable ontology analytics (cloudflare)
     @settings.enable_cloudflare_analytics ||= true
+    # enable ontology rank generation
+    @settings.enable_ontology_rank ||= true
     # enable ontologies report
     @settings.enable_ontologies_report ||= true
     # enable index synchronization
@@ -66,6 +68,9 @@ module NcboCron
     # Cloudflare analytics schedule
     # 0 1 * * * - run daily at 1:00am
     @settings.cron_cloudflare_analytics ||= '0 1 * * *'
+    # Ontology rank generation schedule
+    # 0 4 * * 1 - run once a week on Monday at 4:00AM
+    @settings.cron_ontology_rank ||= '0 4 * * 1'
     # Ontologies report generation schedule
     # 30 1 * * * - run daily at 1:30AM
     @settings.cron_ontologies_report ||= "30 1 * * *"

--- a/lib/ncbo_cron/ontology_rank.rb
+++ b/lib/ncbo_cron/ontology_rank.rb
@@ -1,20 +1,24 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'benchmark'
 require_relative 'ontology_helper'
 
 module NcboCron
   module Models
-
+    # Generates rankings for ontologies based on BioPortal analytics data and UMLS group membership.
+    # Rankings combine visit statistics (normalized using log10) with binary UMLS scoring.
+    # Results are stored in Redis for application use.
     class OntologyRank
-      ONTOLOGY_RANK_REDIS_FIELD = "ontology_rank"
+      ONTOLOGY_RANK_REDIS_FIELD = 'ontology_rank'
       BP_VISITS_NUMBER_MONTHS = 12
 
-      def initialize(logger=nil)
+      def initialize(logger = nil)
         @logger = nil
         if logger.nil?
-          log_file = File.new(NcboCron.settings.log_path, "a")
+          log_file = File.new(NcboCron.settings.log_path, 'a')
           log_path = File.dirname(File.absolute_path(log_file))
-          log_filename_no_ext = File.basename(log_file, ".*")
+          log_filename_no_ext = File.basename(log_file, '.*')
           ontology_rank_log_path = File.join(log_path, "#{log_filename_no_ext}-ontology-rank.log")
           @logger = Logger.new(ontology_rank_log_path)
         else
@@ -28,16 +32,16 @@ module NcboCron
         logger.flush
 
         time = Benchmark.realtime do
-          logger.info("Connecting to Redis at " \
+          logger.info('Connecting to Redis at ' \
                        "#{NcboCron.settings.redis_host}:#{NcboCron.settings.redis_port}")
-          redis = Redis.new(:host => NcboCron.settings.redis_host, :port => NcboCron.settings.redis_port)
+          redis = Redis.new(host: NcboCron.settings.redis_host, port: NcboCron.settings.redis_port)
           logger.info('Redis connection established successfully')
           logger.info('')
           logger.flush
 
           logger.info('Beginning ontology ranking calculation...')
           ontology_rank = rank_ontologies
-          logger.info("Ranking calculation completed. Generated rankings for " \
+          logger.info('Ranking calculation completed. Generated rankings for ' \
                        "#{ontology_rank.keys.size} ontologies")
           logger.info('')
 
@@ -68,13 +72,20 @@ module NcboCron
 
         logger.info('Combining scores to generate final rankings...')
         ontology_rank = {}
-        @analytics_scr.each {|acronym, score| ontology_rank[acronym] = {bioportalScore: score.round(3), umlsScore: @umls_scr[acronym] ? @umls_scr[acronym].round(3) : 0.0}}
+        @analytics_scr.each do |acronym, score|
+          umls_score = @umls_scr[acronym] ? @umls_scr[acronym].round(3) : 0.0
+          ontology_rank[acronym] = {
+            bioportalScore: score.round(3),
+            umlsScore: umls_score
+          }
+          # logger.debug("#{acronym}: BP=#{score.round(3)}, UMLS=#{umls_score}")
+        end
 
         # Log summary statistics
         bp_scores = ontology_rank.values.map { |v| v[:bioportalScore] }
         umls_scores = ontology_rank.values.map { |v| v[:umlsScore] }
 
-        logger.info("Final rankings summary:")
+        logger.info('Final rankings summary:')
         logger.info("  BioPortal scores - Min: #{bp_scores.min}, Max: #{bp_scores.max}, " \
                      "Avg: #{(bp_scores.sum / bp_scores.size).round(3)}")
         logger.info("  UMLS scores - Min: #{umls_scores.min}, Max: #{umls_scores.max}, " \
@@ -96,31 +107,31 @@ module NcboCron
         total_visits = visits_hash.values.sum
         max_visits = visits_hash.values.max || 0
         min_visits = visits_hash.values.min || 0
-        logger.info("Visit statistics:")
+        logger.info('Visit statistics:')
         logger.info("  Total visits across all ontologies: #{total_visits}")
         logger.info("  Maximum visits for single ontology: #{max_visits}")
         logger.info("  Minimum visits for single ontology: #{min_visits}")
         logger.info("  Ontologies with zero visits: #{visits_hash.values.count(0)}")
 
         # Find top 5 most visited ontologies
-        top_ontologies = visits_hash.sort_by { |k, v| -v }.first(5)
-        logger.info("Top 5 most visited ontologies:")
+        top_ontologies = visits_hash.sort_by { |_k, v| -v }.first(5)
+        logger.info('Top 5 most visited ontologies:')
         top_ontologies.each_with_index do |(acronym, visits), index|
           logger.info("  #{index + 1}. #{acronym}: #{visits} visits")
         end
 
         # log10 normalization and range change to [0,1]
         logger.info('Applying log10 normalization...')
-        if !visits_hash.values.max.nil? && visits_hash.values.max > 0
+        if !visits_hash.values.max.nil? && visits_hash.values.max.positive?
           norm_max_visits = Math.log10(visits_hash.values.max)
           logger.info("Normalization factor (log10 of max visits): #{norm_max_visits.round(3)}")
         else
           norm_max_visits = 1
-          logger.info("No visits found, using normalization factor of 1")
+          logger.info('No visits found, using normalization factor of 1')
         end
 
         visits_hash.each do |acr, visits|
-          norm_visits = visits > 0 ? Math.log10(visits) : 0
+          norm_visits = visits.positive? ? Math.log10(visits) : 0
           visits_hash[acr] = normalize(norm_visits, 0, norm_max_visits, 0, 1)
         end
         visits_hash
@@ -131,7 +142,7 @@ module NcboCron
 
         ontologies.each do |ont|
           if ont.group && !ont.group.empty?
-            umls_gr = ont.group.select {|gr| NcboCron::Helpers::OntologyHelper.last_fragment_of_uri(gr.id.to_s).include?('UMLS')}
+            umls_gr = ont.group.select { |gr| NcboCron::Helpers::OntologyHelper.last_fragment_of_uri(gr.id.to_s).include?('UMLS') }
             scores[ont.acronym] = umls_gr.empty? ? 0 : 1
           else
             scores[ont.acronym] = 0
@@ -143,17 +154,18 @@ module NcboCron
       def normalize(x, xmin, xmax, ymin, ymax)
         xrange = xmax - xmin
         yrange = ymax - ymin
-        return ymin if xrange == 0
-        ymin + (x - xmin) * (yrange.to_f / xrange.to_f)
+        return ymin if xrange.zero?
+
+        ymin + (x - xmin) * (yrange.to_f / xrange)
       end
 
       # Return a hash |acronym, visits| for the last num_months. The result is ranked by visits
       def visits_for_period(ontologies, num_months, current_year, current_month)
         # Visits for all BioPortal ontologies
-        acronyms = ontologies.map {|o| o.acronym }
+        acronyms = ontologies.map(&:acronym)
         bp_all_visits = LinkedData::Models::Ontology.analytics(nil, nil, acronyms)
         periods = last_periods(num_months, current_year, current_month)
-        period_visits = Hash.new
+        period_visits = {}
         bp_all_visits.each do |acronym, visits|
           period_visits[acronym] = 0
           periods.each do |p|
@@ -182,7 +194,6 @@ module NcboCron
         end
         periods
       end
-
     end
   end
 end

--- a/lib/ncbo_cron/ontology_rank.rb
+++ b/lib/ncbo_cron/ontology_rank.rb
@@ -157,7 +157,10 @@ module NcboCron
         bp_all_visits.each do |acronym, visits|
           period_visits[acronym] = 0
           periods.each do |p|
-            period_visits[acronym] += visits[p[0]] ? visits[p[0]][p[1]] || 0 : 0
+            year_str = p[0].to_s
+            month_str = p[1].to_s
+            month_visits = visits[year_str] ? visits[year_str][month_str] || 0 : 0
+            period_visits[acronym] += month_visits
           end
         end
         period_visits

--- a/lib/ncbo_cron/ontology_rank.rb
+++ b/lib/ncbo_cron/ontology_rank.rb
@@ -23,36 +23,100 @@ module NcboCron
       end
 
       def run
-        @logger.info("Generating ontology rankings..."); @logger.flush
-        @logger.flush
+        logger.info('-' * 50)
+        logger.info('Starting ontology ranking process...')
+        logger.flush
 
         time = Benchmark.realtime do
+          logger.info("Connecting to Redis at " \
+                       "#{NcboCron.settings.redis_host}:#{NcboCron.settings.redis_port}")
           redis = Redis.new(:host => NcboCron.settings.redis_host, :port => NcboCron.settings.redis_port)
+          logger.info('Redis connection established successfully')
+          logger.info('')
+          logger.flush
+
+          logger.info('Beginning ontology ranking calculation...')
           ontology_rank = rank_ontologies
+          logger.info("Ranking calculation completed. Generated rankings for " \
+                       "#{ontology_rank.keys.size} ontologies")
+          logger.info('')
+
+          logger.info('Storing rankings in Redis...')
           redis.set(ONTOLOGY_RANK_REDIS_FIELD, Marshal.dump(ontology_rank))
+          logger.info('Rankings successfully stored in Redis')
         end
-        @logger.info("Finished generating ontology rankings in #{time} sec."); @logger.flush
+
+        logger.info("Finished generating ontology rankings in #{time.round(3)} seconds")
+        logger.info('Process completed successfully')
+        logger.flush
       end
 
       def rank_ontologies
-        ontology_rank = {}
         ontologies = LinkedData::Models::Ontology.where.include(:acronym, :group).to_a
-        analytics_scr = analytics_scores(ontologies)
-        umls_scr = umls_scores(ontologies)
-        analytics_scr.each {|acronym, score| ontology_rank[acronym] = {bioportalScore: score.round(3), umlsScore: umls_scr[acronym] ? umls_scr[acronym].round(3) : 0.0}}
+
+        logger.info('Calculating analytics scores...')
+        analytics_time = Benchmark.realtime do
+          @analytics_scr = analytics_scores(ontologies)
+        end
+        logger.info("Analytics scores calculated in #{analytics_time.round(3)} seconds")
+
+        logger.info('Calculating UMLS scores...')
+        umls_time = Benchmark.realtime do
+          @umls_scr = umls_scores(ontologies)
+        end
+        logger.info("UMLS scores calculated in #{umls_time.round(3)} seconds")
+
+        logger.info('Combining scores to generate final rankings...')
+        ontology_rank = {}
+        @analytics_scr.each {|acronym, score| ontology_rank[acronym] = {bioportalScore: score.round(3), umlsScore: @umls_scr[acronym] ? @umls_scr[acronym].round(3) : 0.0}}
+
+        # Log summary statistics
+        bp_scores = ontology_rank.values.map { |v| v[:bioportalScore] }
+        umls_scores = ontology_rank.values.map { |v| v[:umlsScore] }
+
+        logger.info("Final rankings summary:")
+        logger.info("  BioPortal scores - Min: #{bp_scores.min}, Max: #{bp_scores.max}, " \
+                     "Avg: #{(bp_scores.sum / bp_scores.size).round(3)}")
+        logger.info("  UMLS scores - Min: #{umls_scores.min}, Max: #{umls_scores.max}, " \
+                     "Total with UMLS: #{umls_scores.count(&:positive?)}")
+        logger.flush
+
         ontology_rank
       end
 
       private
 
+      def logger
+        @logger || Logger.new($stdout)
+      end
+
       def analytics_scores(ontologies)
         visits_hash = visits_for_period(ontologies, BP_VISITS_NUMBER_MONTHS, Time.now.year, Time.now.month)
 
+        total_visits = visits_hash.values.sum
+        max_visits = visits_hash.values.max || 0
+        min_visits = visits_hash.values.min || 0
+        logger.info("Visit statistics:")
+        logger.info("  Total visits across all ontologies: #{total_visits}")
+        logger.info("  Maximum visits for single ontology: #{max_visits}")
+        logger.info("  Minimum visits for single ontology: #{min_visits}")
+        logger.info("  Ontologies with zero visits: #{visits_hash.values.count(0)}")
+
+        # Find top 5 most visited ontologies
+        top_ontologies = visits_hash.sort_by { |k, v| -v }.first(5)
+        logger.info("Top 5 most visited ontologies:")
+        top_ontologies.each_with_index do |(acronym, visits), index|
+          logger.info("  #{index + 1}. #{acronym}: #{visits} visits")
+        end
+
         # log10 normalization and range change to [0,1]
+        logger.info('Applying log10 normalization...')
         if !visits_hash.values.max.nil? && visits_hash.values.max > 0
           norm_max_visits = Math.log10(visits_hash.values.max)
+          logger.info("Normalization factor (log10 of max visits): #{norm_max_visits.round(3)}")
         else
           norm_max_visits = 1
+          logger.info("No visits found, using normalization factor of 1")
         end
 
         visits_hash.each do |acr, visits|
@@ -126,6 +190,9 @@ end
 # require 'ncbo_cron/config'
 # require_relative '../../config/config'
 #
-# ontology_rank_path = File.join("logs", "ontology-rank.log")
+# logger = Logger.new($stdout)
+# NcboCron::Models::OntologyRank.new(logger).run
+#
+# ontology_rank_path = File.join("log", "ontology-rank.log")
 # ontology_rank_logger = Logger.new(ontology_rank_path)
 # NcboCron::Models::OntologyRank.new(ontology_rank_logger).run


### PR DESCRIPTION
* Fixed a data type mismatch in analytics data lookup. Analytics data uses string keys ("2025", "1") but the code was accessing it with integer keys, causing all visit counts to be zero.
* Resolves [#114](https://github.com/ncbo/ncbo_cron/issues/114): _Ontology rank: bioportalScore is 0.0 for all ontologies_
* Promoted the `OntologyRank` job to run independently on Mondays at 4:00 AM. Previously, it was executed as part of the Google Analytics collection. Since BioPortal now uses Cloudflare Web Analytics, the ranking process must run separately.
* Added detailed info-level logging throughout the ranking workflow to provide visibility into data processing steps, performance timing, and computed ranking statistics.
* Added minimal class-level documentation.
* Fixed various RuboCop warnings.
