### PR TITLE
Chore/fix deprecated Dir.exists?

### DIFF
--- a/lib/ncbo_cron/ontology_analytics.rb
+++ b/lib/ncbo_cron/ontology_analytics.rb
@@ -155,7 +155,7 @@ module NcboCron
       def merge_and_fill_missing_data(ga4_data)
         ua_data = {}
 
-        if File.exists?(NcboCron.settings.analytics_path_to_ua_data_file) &&
+        if File.exist?(NcboCron.settings.analytics_path_to_ua_data_file) &&
             !File.zero?(NcboCron.settings.analytics_path_to_ua_data_file)
           @logger.info "Merging GA4 and UA data..."
           @logger.flush

--- a/lib/ncbo_cron/ontology_submission_parser.rb
+++ b/lib/ncbo_cron/ontology_submission_parser.rb
@@ -150,7 +150,7 @@ module NcboCron
         if sub
           sub.bring_remaining
           sub.ontology.bring(:acronym)
-          FileUtils.mkdir_p(sub.data_folder) unless Dir.exists?(sub.data_folder)
+          FileUtils.mkdir_p(sub.data_folder)
           log_path = sub.parsing_log_path
           logger.info "Logging parsing output to #{log_path}"
           logger1 = Logger.new(log_path)


### PR DESCRIPTION
Ruby 3 cleanup: replace `Dir.exists?` with `Dir.exist?` and remove redundant check