### PR TITLE
Improve ontology processing selection, ordering, and interrupt handling

### DIFF
--- a/bin/delete_bad_submissions.rb
+++ b/bin/delete_bad_submissions.rb
@@ -54,7 +54,9 @@ LinkedData::Models::Ontology.all.each do |ont|
         bad_subs << s
         logger.info("Submission id is not numeric #{s.id}: #{s.submissionId.class}")
       end
-    rescue Exception => e
+    rescue SystemExit, Interrupt
+      raise
+    rescue StandardError => e
       bad_subs << s
       logger.info("Error retrieving submission id #{s.id}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
     end
@@ -64,7 +66,9 @@ LinkedData::Models::Ontology.all.each do |ont|
         bad_subs << s
         puts "#{s.id}: hasOntologyLanguage nil"
       end
-    rescue Exception => e
+    rescue SystemExit, Interrupt
+      raise
+    rescue StandardError => e
       bad_subs << s
       logger.info("Error retrieving hasOntologyLanguage for submission #{s.id}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
     end

--- a/bin/delete_bad_submissions.rb
+++ b/bin/delete_bad_submissions.rb
@@ -54,9 +54,8 @@ LinkedData::Models::Ontology.all.each do |ont|
         bad_subs << s
         logger.info("Submission id is not numeric #{s.id}: #{s.submissionId.class}")
       end
-    rescue SystemExit, Interrupt
-      raise
-    rescue StandardError => e
+    rescue Exception => e
+      raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
       bad_subs << s
       logger.info("Error retrieving submission id #{s.id}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
     end
@@ -66,9 +65,8 @@ LinkedData::Models::Ontology.all.each do |ont|
         bad_subs << s
         puts "#{s.id}: hasOntologyLanguage nil"
       end
-    rescue SystemExit, Interrupt
-      raise
-    rescue StandardError => e
+    rescue Exception => e
+      raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
       bad_subs << s
       logger.info("Error retrieving hasOntologyLanguage for submission #{s.id}: #{e.class}: #{e.message}\n#{e.backtrace.join("\n\t")}")
     end

--- a/bin/ncbo_ontology_analytics_rebuild
+++ b/bin/ncbo_ontology_analytics_rebuild
@@ -57,7 +57,9 @@ begin
   msg = "Completed rebuilding ontology analytics repository in #{(time/60).round(1)} minutes."
   puts msg
   logger.info(msg)
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed rebuilding ontology analytics repository with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_ontology_annotate_generate_cache
+++ b/bin/ncbo_ontology_annotate_generate_cache
@@ -136,7 +136,9 @@ begin
     puts msg
     logger.info(msg)
   end
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed Annotator cache processing with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   puts msg
   logger.error(msg)

--- a/bin/ncbo_ontology_annotate_generate_dictionary
+++ b/bin/ncbo_ontology_annotate_generate_dictionary
@@ -44,10 +44,11 @@ begin
   puts "Processing details are logged to #{options[:logfile]}"
   annotator = Annotator::Models::NcboAnnotator.new
   annotator.generate_dictionary_file()
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed, exception: #{e.to_json}."
   logger.error(msg)
   puts msg
   exit(1)
 end
-

--- a/bin/ncbo_ontology_delete
+++ b/bin/ncbo_ontology_delete
@@ -57,10 +57,11 @@ begin
   # deleting ontology from report
   NcboCron::Models::OntologiesReport.new(logger).delete_ontologies_from_report([options[:ontology]])
   logger.info("Ontology deleted: #{options[:ontology]}")
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed, exception: #{e.to_json}."
   logger.error(msg)
   puts msg
   exit(1)
 end
-

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -107,7 +107,9 @@ def index_ontology(indexed_ontologies, acronym, logger)
     # removal of the old index and committing a new index.  There is no 'dry-run' option.
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_search: true})
     indexed_ontologies << acronym
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     msg = "Exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
     puts msg
     logger.error(msg)
@@ -186,7 +188,9 @@ begin
   end
   puts msg
   logger.info(msg)
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed indexing with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -107,9 +107,8 @@ def index_ontology(indexed_ontologies, acronym, logger)
     # removal of the old index and committing a new index.  There is no 'dry-run' option.
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_search: true})
     indexed_ontologies << acronym
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     msg = "Exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
     puts msg
     logger.error(msg)

--- a/bin/ncbo_ontology_inspector
+++ b/bin/ncbo_ontology_inspector
@@ -221,7 +221,9 @@ def submission_status4annotator(sub, submission_status)
     else
       submission_status.push('ANNOTATIONS_MISSING_DATA')
     end
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     submission_status.push("ANNOTATIONS_ERROR:#{e.message}")
   end
 end

--- a/bin/ncbo_ontology_mapping_counts
+++ b/bin/ncbo_ontology_mapping_counts
@@ -97,7 +97,9 @@ begin
     puts msg
     logger.info(msg)
   end
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed rebuilding #{options[:task]} with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_ontology_metrics
+++ b/bin/ncbo_ontology_metrics
@@ -78,9 +78,8 @@ def generate_metrics_for_ontology(finished_ontologies, acronym, logger)
                                                                       index_search: false, index_commit: false,
                                                                       run_metrics: true, reasoning: false, diff: false})
     finished_ontologies << acronym
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     msg = "Exception: #{e.to_json}"
     puts msg
     logger.error(msg)

--- a/bin/ncbo_ontology_metrics
+++ b/bin/ncbo_ontology_metrics
@@ -78,7 +78,9 @@ def generate_metrics_for_ontology(finished_ontologies, acronym, logger)
                                                                       index_search: false, index_commit: false,
                                                                       run_metrics: true, reasoning: false, diff: false})
     finished_ontologies << acronym
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     msg = "Exception: #{e.to_json}"
     puts msg
     logger.error(msg)
@@ -118,7 +120,9 @@ begin
   end
   puts msg
   logger.info(msg)
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed metrics generation with exception: #{e.to_json}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_ontology_process
+++ b/bin/ncbo_ontology_process
@@ -25,9 +25,17 @@ def sort_and_prioritize_ontologies(ontologies)
   priority_ontologies.concat(env_priority_ontologies)
   priority_ontologies.uniq!
 
-  sorted_ontologies = ontologies.uniq.sort
-  priority, remaining = sorted_ontologies.partition { |acronym| priority_ontologies.include?(acronym) }
-  priority + remaining
+  ontology_records = ontologies.uniq.sort.map do |acronym|
+    ont = LinkedData::Models::Ontology.find(acronym).include(:acronym, :viewingRestriction).first
+    {
+      acronym: acronym,
+      private: !ont.nil? && ont.viewingRestriction != 'public'
+    }
+  end
+
+  priority, remaining = ontology_records.partition { |ontology| priority_ontologies.include?(ontology[:acronym]) }
+  remaining_public, remaining_private = remaining.partition { |ontology| !ontology[:private] }
+  (priority + remaining_public + remaining_private).map { |ontology| ontology[:acronym] }
 end
 
 options = {all: false}
@@ -118,6 +126,7 @@ end
 logger = Logger.new(options[:logfile])
 puts "Processing details are logged to #{options[:logfile] == STDOUT ? "STDOUT" : options[:logfile]}"
 
+remaining_ontologies = options[:ontologies].length
 options[:ontologies].each do |acronym|
   begin
     ont = LinkedData::Models::Ontology.find(acronym).first
@@ -136,10 +145,16 @@ options[:ontologies].each do |acronym|
     end
 
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, options[:tasks])
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     msg = "Failed, exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
     logger.error(msg)
+  ensure
+    remaining_ontologies -= 1
+    if remaining_ontologies > 0
+      msg = "There #{remaining_ontologies == 1 ? 'is' : 'are'} #{remaining_ontologies} ontolog#{remaining_ontologies == 1 ? 'y' : 'ies'} left to process."
+      puts msg
+      logger.info(msg)
+    end
   end
 end

--- a/bin/ncbo_ontology_process
+++ b/bin/ncbo_ontology_process
@@ -16,21 +16,36 @@ require 'optparse'
 # do not send notifications to ontology owners when running this script
 LinkedData.settings.enable_notifications = false
 
+PRIORITY_ONTOLOGIES = [].freeze
+PRIORITY_ONTOLOGIES_ENV = 'NCBO_ONTOLOGY_PROCESS_PRIORITY_ONTOLOGIES'.freeze
+
+def sort_and_prioritize_ontologies(ontologies)
+  priority_ontologies = PRIORITY_ONTOLOGIES.dup
+  env_priority_ontologies = ENV.fetch(PRIORITY_ONTOLOGIES_ENV, '').split(',').map { |o| o.strip }.reject(&:empty?)
+  priority_ontologies.concat(env_priority_ontologies)
+  priority_ontologies.uniq!
+
+  sorted_ontologies = ontologies.uniq.sort
+  priority, remaining = sorted_ontologies.partition { |acronym| priority_ontologies.include?(acronym) }
+  priority + remaining
+end
+
 options = {all: false}
 opt_parser = OptionParser.new do |opts|
   # Set a banner, displayed at the top of the help screen.
   #opts.banner = "Usage: ncbo_ontology_process [options]"
   options[:ontologies] = []
+  options[:exclude_ontologies] = []
   opts.on('-a', '--all-ontologies', 'Process all ontologies (this or -o option required).') do
-    LinkedData::Models::Ontology.all.each  do |ont|
-      ont.bring(:acronym)
-      options[:ontologies].push(ont.acronym)
-    end
     options[:all] = true
   end
 
   opts.on('-o', '--ontologies ACRONYM1,ACRONYM2,ACRONYM3', 'Comma-separated list of ontologies to process (this or -a option required).') do |acronyms|
     options[:ontologies] = acronyms.split(",").map {|o| o.strip}
+  end
+
+  opts.on('-x', '--exclude-ontologies ACRONYM1,ACRONYM2,ACRONYM3', 'Comma-separated list of ontologies to exclude when using -a.') do |acronyms|
+    options[:exclude_ontologies] = acronyms.split(",").map {|o| o.strip}
   end
 
   options[:tasks] = NcboCron::Models::OntologySubmissionParser::ACTIONS
@@ -58,6 +73,22 @@ end
 # Parse the command-line. The 'parse' method simply parses ARGV, while the 'parse!' method parses ARGV and removes
 # any options found there, as well as any parameters for the options.
 opt_parser.parse!
+if !options[:all] && !options[:exclude_ontologies].empty?
+  puts '--exclude-ontologies can only be used with --all-ontologies'
+  puts opt_parser.help
+  exit(1)
+end
+
+if options[:all]
+  LinkedData::Models::Ontology.all.each do |ont|
+    ont.bring(:acronym)
+    options[:ontologies].push(ont.acronym)
+  end
+  options[:ontologies] -= options[:exclude_ontologies]
+end
+
+options[:ontologies] = sort_and_prioritize_ontologies(options[:ontologies])
+
 if options[:ontologies].empty?
   puts opt_parser.help
   exit(1)
@@ -74,7 +105,8 @@ end
 # MAIN
 #
 if options[:all]
-  puts "About to perform the following tasks on ALL ontologies: #{options[:tasks]}"
+  excl_msg = options[:exclude_ontologies].empty? ? '' : " excluding #{options[:exclude_ontologies]}"
+  puts "About to perform the following tasks on ALL ontologies#{excl_msg}: #{options[:tasks]}"
   puts "Type 'yes' to continue: "
   $stdout.flush
   confirm = $stdin.gets
@@ -104,9 +136,10 @@ options[:ontologies].each do |acronym|
     end
 
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, options[:tasks])
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     msg = "Failed, exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
     logger.error(msg)
   end
 end
-

--- a/bin/ncbo_ontology_property_index
+++ b/bin/ncbo_ontology_property_index
@@ -98,9 +98,8 @@ def index_ontology_properties(indexed_ontologies, acronym, logger)
 
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_properties: true})
     indexed_ontologies << acronym
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     msg = "Exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
     logger.error(msg)
   end

--- a/bin/ncbo_ontology_property_index
+++ b/bin/ncbo_ontology_property_index
@@ -98,7 +98,9 @@ def index_ontology_properties(indexed_ontologies, acronym, logger)
 
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_properties: true})
     indexed_ontologies << acronym
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     msg = "Exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
     logger.error(msg)
   end
@@ -176,7 +178,9 @@ begin
   end
   puts msg
   logger.info(msg)
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed property indexing with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_ontology_report_rebuild
+++ b/bin/ncbo_ontology_report_rebuild
@@ -57,7 +57,9 @@ begin
   msg = "Completed rebuilding ontologies report in #{(time/60).round(1)} minutes."
   puts msg
   logger.info(msg)
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed rebuilding ontologies report with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_spam_deletion
+++ b/bin/ncbo_spam_deletion
@@ -60,7 +60,9 @@ begin
     msg = "Completed clearing Goo/HTTP caches"
     logger.info(msg)
   end
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed SPAM removal with exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg

--- a/bin/ncbo_submission_filepath_corrections
+++ b/bin/ncbo_submission_filepath_corrections
@@ -63,9 +63,8 @@ def create_submission_path(sub, ont)
   upload_file_path = "#{LinkedData.settings.repository_folder}/#{ont.acronym}/#{sub.submissionId}"
   begin
     FileUtils.mkdir_p upload_file_path
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     $logger.error("Failed to create submission repository directory.")
     raise e
   end
@@ -99,9 +98,8 @@ def retrievePullLocation2uploadFilePath(sub, ont)
     else
       raise "Remote file doesn't exist"
     end
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     $logger.error "Problem retrieving #{sub.pullLocation}:\n" + e.message + "\n" + e.backtrace.join("\n\t")
     $logger.flush()
   end
@@ -155,9 +153,8 @@ def process_submission_upload(sub, ont)
       begin
         FileUtils.copy(sub.uploadFilePath, upload_file, {:preserve => true, :verbose => true} )
         sub.uploadFilePath = upload_file
-      rescue SystemExit, Interrupt
-        raise
-      rescue StandardError => e
+      rescue Exception => e
+        raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
         if e.message.start_with? 'same file:'
           # If it's the same file, it's probably a symlink and we can update the sub.uploadFilePath anyway.
           sub.uploadFilePath = upload_file
@@ -173,9 +170,8 @@ def process_submission_upload(sub, ont)
       else
         $logger.error("Failed to update the triple store: #{sub.errors.to_json}" )
       end
-    rescue SystemExit, Interrupt
-      raise
-    rescue StandardError => e
+    rescue Exception => e
+      raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
       $logger.error("Failed to relocate the upload file")
       raise e
     end
@@ -187,9 +183,8 @@ def process_submission_upload(sub, ont)
         begin
           FileUtils.copy(sub.diffFilePath, diff_file, {:preserve => true, :verbose => true} )
           sub.diffFilePath = diff_file
-        rescue SystemExit, Interrupt
-          raise
-        rescue StandardError => e
+        rescue Exception => e
+          raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
           if e.message.start_with? 'same file:'
             # If it's the same file, it's probably a symlink and we can update the sub.diffFilePath anyway.
             sub.diffFilePath = diff_file
@@ -206,9 +201,8 @@ def process_submission_upload(sub, ont)
           $logger.error("Failed to update the triple store: #{sub.errors.to_json}" )
         end
       end
-    rescue SystemExit, Interrupt
-      raise
-    rescue StandardError => e
+    rescue Exception => e
+      raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
       $logger.error("Failed to relocate the diff file")
       raise e
     end
@@ -245,9 +239,8 @@ ontologies.each do |ont|
   submissions.each do |sub|
     begin
       process_submission_upload(sub, ont)
-    rescue SystemExit, Interrupt
-      raise
-    rescue StandardError => e
+    rescue Exception => e
+      raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
       $logger.error(e.message)
     end
   end

--- a/bin/ncbo_submission_filepath_corrections
+++ b/bin/ncbo_submission_filepath_corrections
@@ -63,7 +63,9 @@ def create_submission_path(sub, ont)
   upload_file_path = "#{LinkedData.settings.repository_folder}/#{ont.acronym}/#{sub.submissionId}"
   begin
     FileUtils.mkdir_p upload_file_path
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     $logger.error("Failed to create submission repository directory.")
     raise e
   end
@@ -97,7 +99,9 @@ def retrievePullLocation2uploadFilePath(sub, ont)
     else
       raise "Remote file doesn't exist"
     end
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     $logger.error "Problem retrieving #{sub.pullLocation}:\n" + e.message + "\n" + e.backtrace.join("\n\t")
     $logger.flush()
   end
@@ -151,7 +155,9 @@ def process_submission_upload(sub, ont)
       begin
         FileUtils.copy(sub.uploadFilePath, upload_file, {:preserve => true, :verbose => true} )
         sub.uploadFilePath = upload_file
-      rescue Exception => e
+      rescue SystemExit, Interrupt
+        raise
+      rescue StandardError => e
         if e.message.start_with? 'same file:'
           # If it's the same file, it's probably a symlink and we can update the sub.uploadFilePath anyway.
           sub.uploadFilePath = upload_file
@@ -167,7 +173,9 @@ def process_submission_upload(sub, ont)
       else
         $logger.error("Failed to update the triple store: #{sub.errors.to_json}" )
       end
-    rescue Exception => e
+    rescue SystemExit, Interrupt
+      raise
+    rescue StandardError => e
       $logger.error("Failed to relocate the upload file")
       raise e
     end
@@ -179,7 +187,9 @@ def process_submission_upload(sub, ont)
         begin
           FileUtils.copy(sub.diffFilePath, diff_file, {:preserve => true, :verbose => true} )
           sub.diffFilePath = diff_file
-        rescue Exception => e
+        rescue SystemExit, Interrupt
+          raise
+        rescue StandardError => e
           if e.message.start_with? 'same file:'
             # If it's the same file, it's probably a symlink and we can update the sub.diffFilePath anyway.
             sub.diffFilePath = diff_file
@@ -196,7 +206,9 @@ def process_submission_upload(sub, ont)
           $logger.error("Failed to update the triple store: #{sub.errors.to_json}" )
         end
       end
-    rescue Exception => e
+    rescue SystemExit, Interrupt
+      raise
+    rescue StandardError => e
       $logger.error("Failed to relocate the diff file")
       raise e
     end
@@ -233,9 +245,10 @@ ontologies.each do |ont|
   submissions.each do |sub|
     begin
       process_submission_upload(sub, ont)
-    rescue Exception => e
+    rescue SystemExit, Interrupt
+      raise
+    rescue StandardError => e
       $logger.error(e.message)
     end
   end
 end
-

--- a/bin/ncbo_submission_pull_location_failures
+++ b/bin/ncbo_submission_pull_location_failures
@@ -72,9 +72,8 @@ def check_http_file(uri)
       response = http.get(uri.request_uri)
       return response.code
     end
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     puts e.message
     return 500
   end
@@ -85,9 +84,8 @@ def check_ftp_file(uri)
   ftp.login
   begin
     return ftp.size(uri.path) > 0
-  rescue SystemExit, Interrupt
-    raise
-  rescue StandardError => e
+  rescue Exception => e
+    raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
     # Check using another method
     path = uri.path.split("/")
     filename = path.pop

--- a/bin/ncbo_submission_pull_location_failures
+++ b/bin/ncbo_submission_pull_location_failures
@@ -72,7 +72,9 @@ def check_http_file(uri)
       response = http.get(uri.request_uri)
       return response.code
     end
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     puts e.message
     return 500
   end
@@ -83,7 +85,9 @@ def check_ftp_file(uri)
   ftp.login
   begin
     return ftp.size(uri.path) > 0
-  rescue Exception => e
+  rescue SystemExit, Interrupt
+    raise
+  rescue StandardError => e
     # Check using another method
     path = uri.path.split("/")
     filename = path.pop
@@ -197,4 +201,3 @@ EOS
   end
 
 end
-

--- a/bin/ncbo_update_check
+++ b/bin/ncbo_update_check
@@ -48,7 +48,9 @@ begin
     puts "Update available. See details below:"
     puts update_info
   end
-rescue Exception => e
+rescue SystemExit, Interrupt
+  raise
+rescue StandardError => e
   msg = "Failed update check - #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
   logger.error(msg)
   puts msg


### PR DESCRIPTION
### Summary

This PR updates `bin/ncbo_ontology_process` and related bin/ scripts to make bulk ontology processing more deterministic and easier to control. In particular, it adds explicit ordering so large or high-priority ontologies can be processed first, which makes failures show up earlier instead of after waiting through an arbitrary processing order.

In `bin/ncbo_ontology_process`, it adds support for excluding specific ontologies when running with -a/--all-ontologies, sorts the final ontology list alphabetically, and allows selected ontologies to be prioritized to the front of the queue via a hardcoded list or the `NCBO_ONTOLOGY_PROCESS_PRIORITY_ONTOLOGIES` environment variable.

The PR also revisits SIGINT handling. The original issue was that several scripts trapped SIGINT with exit 1, but broad exception handlers could swallow that and keep the process running after Ctrl+C. For `bin/ncbo_ontology_process`, and for batch-style scripts that are expected to continue after per-item failures, the rescue behavior is now:

  - preserve Ctrl+C / SIGINT
  - preserve normal exit / abort behavior
  - still log ontology-level failures and continue to the next item, even when lower-level libraries raise `Exception` directly. The choice of raising `Exception` instead of `StandardError` is an intentional compromise until exception usage is cleaned up in upstream dependencies such as Goo. Related upstream issue: ncbo/goo#179.

###  Changes

  - Add -x/--exclude-ontologies to bin/ncbo_ontology_process
  - Resolve ontology selection after option parsing so exclusions work regardless of CLI flag order
  - Sort the final ontology list alphabetically before processing
  - Add priority ontology ordering support via:
      - PRIORITY_ONTOLOGIES
      - NCBO_ONTOLOGY_PROCESS_PRIORITY_ONTOLOGIES
  - Fix interrupt handling in bin/ncbo_ontology_process
  - Add progress output showing how many ontologies remain to be processed
  - Apply the same interrupt-safe rescue pattern to other affected bin/ scripts

```
## Ordering behavior in bin/ncbo_ontology_process:

  1. Start from the selected ontology set (-a or -o)
  2. Remove excluded ontologies
  3. Sort alphabetically
  4. Move priority ontologies to the front
  5. Move private ontologies to the end

  This makes processing order stable and intentional.