### PR TITLE
Disable index_all_data in default PROCESS_ACTIONS

### DIFF
--- a/lib/ncbo_cron/ontology_helper.rb
+++ b/lib/ncbo_cron/ontology_helper.rb
@@ -10,7 +10,7 @@ module NcboCron
         :process_rdf => true,
         :generate_labels => true,
         :extract_metadata => true,
-        :index_all_data => true,
+        :index_all_data => false,
         :index_search => true,
         :index_properties => true,
         :run_metrics => true,


### PR DESCRIPTION
## Description

Companion change to ncbo/ontologies_linked_data — disables the index_all_data action by default in cron job processing to prevent creation of the :ontology_data Solr collection with unbounded dynamic fields.

## Prerequisite

- https://github.com/ncbo/ontologies_linked_data/pull/273