### PR TITLE
Feature: Add alias-based Solr rebuild and cutover workflow to cron scripts (ALT)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ gem 'rest-client'
 gem 'sys-proctable'
 
 # NCBO
-gem 'goo', github: 'ncbo/goo', branch: 'development'
+gem 'goo', github: 'ncbo/goo', branch: 'feature/solrcloud-alias-indexing-claude'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'feature/solrcloud-alias-indexing-claude'
 
 group :development do
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: fa850f46c94e09b6368ed47728b9cce05b7e9d54
-  branch: development
+  revision: b28b43df426ff24e4e13001d3c1d773dbf8b8575
+  branch: feature/solrcloud-alias-indexing-claude
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: a4bbd57fcaa78fa66a11b494384b1791b6e9a6d8
-  branch: develop
+  revision: 974142153de9cd4b1cf66f76366c5f0de7c16980
+  branch: feature/solrcloud-alias-indexing-claude
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: b28b43df426ff24e4e13001d3c1d773dbf8b8575
+  revision: 534648570e056c6da12e12e9f019a14459909dcf
   branch: feature/solrcloud-alias-indexing-claude
   specs:
     goo (0.0.2)
@@ -26,7 +26,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_annotator.git
-  revision: 7755a51ce891763a0ba174813796df116abca8a9
+  revision: 3e9c060baa3505af13671b06b3724524277fa301
   branch: develop
   specs:
     ncbo_annotator (0.0.1)
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 974142153de9cd4b1cf66f76366c5f0de7c16980
+  revision: eed53891f29170fc13d4925606175d53ffc2e122
   branch: feature/solrcloud-alias-indexing-claude
   specs:
     ontologies_linked_data (0.0.1)

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -26,14 +26,13 @@ puts "Running on #{platform} platform"
 require 'benchmark'
 require 'optparse'
 
+ALIAS_NAME = :term_search
+
 options = {all: false}
 opt_parser = OptionParser.new do |opts|
-  opts.on('-c', '--collection NAME', 'Collection name to index into (required with -a). A new collection is created, indexed, then the alias is swapped to it.') do |name|
-    options[:collection] = name
-  end
+  opts.banner = "Usage: #{$0} [options]"
 
-  options[:ontologies] = []
-  opts.on('-a', '--all-ontologies', 'Index all ontologies (this or -o option required).') do
+  opts.on('-a', '--all-ontologies', 'Index all ontologies (this or -o option required, unless using --promote-only).') do
     LinkedData::Models::Ontology.all.each do |ont|
       ont.bring(:acronym)
       options[:ontologies].push(ont.acronym)
@@ -41,37 +40,63 @@ opt_parser = OptionParser.new do |opts|
     options[:all] = true
   end
 
-  opts.on('-o', '--ontologies ACRONYM1,ACRONYM2,ACRONYM3', 'Comma-separated list of ontologies to index (this or -a option required).') do |acronyms|
+  opts.on('-o', '--ontologies ACRONYM1,ACRONYM2,ACRONYM3', 'Comma-separated list of ontologies to index.') do |acronyms|
     options[:ontologies] = acronyms.split(",").map {|o| o.strip}
   end
 
-  opts.on('-z', '--optimize [true/false]', 'Whether to optimize the index after the indexing completion. Default: true') do |optimize|
+  opts.on('-c', '--collection NAME', 'Target collection name (required with -a and --promote-only).') do |name|
+    options[:collection] = name
+  end
+
+  opts.on('-p', '--promote', 'Promote the alias to the new collection after successful indexing. Use with -a -c.') do
+    options[:promote] = true
+  end
+
+  opts.on('--promote-only', 'Promote the alias to an existing collection without rebuilding. Requires -c.') do
+    options[:promote_only] = true
+  end
+
+  opts.on('-z', '--optimize [true/false]', 'Whether to optimize the index after indexing. Default: true') do |optimize|
     options[:optimize] = optimize
   end
 
   options[:logfile] = STDOUT
-  opts.on( '-l', '--logfile FILE', "Write log to FILE (default is STDOUT)" ) do |filename|
+  opts.on('-l', '--logfile FILE', "Write log to FILE (default is STDOUT)") do |filename|
     options[:logfile] = filename
   end
 
-  # Display the help screen, all programs are assumed to have this option.
-  opts.on( '-h', '--help', 'Display this screen' ) do
+  opts.on('-h', '--help', 'Display this screen') do
     puts opts
+    puts
+    puts "Examples:"
+    puts "  Rebuild all into a new collection (no alias swap):"
+    puts "    #{$0} -a -c term_search_rebuild"
+    puts
+    puts "  Rebuild all and promote alias on success:"
+    puts "    #{$0} -a -c term_search_20260401 -p"
+    puts
+    puts "  Promote alias to an existing collection (no rebuild):"
+    puts "    #{$0} --promote-only -c term_search_20260401"
+    puts
+    puts "  Re-index specific ontologies into the live alias:"
+    puts "    #{$0} -o SNOMEDCT,GO"
     exit
   end
 end
 
-# Parse the command-line. The 'parse' method simply parses ARGV, while the 'parse!' method parses ARGV and removes
-# any options found there, as well as any parameters for the options.
+options[:ontologies] = []
 opt_parser.parse!
-unless options[:ontologies]
+
+# Validate option combinations
+if options[:promote_only]
+  abort("Error: -c (collection name) is required with --promote-only.\n\n") if options[:collection].nil?
+  abort("Error: --promote-only cannot be combined with -a or -o.\n\n") if options[:all] || !options[:ontologies].empty?
+elsif options[:all]
+  abort("Error: -c (collection name) is required when using -a.\n" \
+        "Example: #{$0} -a -c term_search_20260413\n\n") if options[:collection].nil?
+elsif options[:ontologies].empty?
   puts opt_parser.help
   exit(1)
-end
-
-if options[:all] && options[:collection].nil?
-  abort("Error: -c (collection name) is required when using -a (all ontologies).\n" \
-        "Example: #{$0} -a -c term_search_20260413\n\n")
 end
 
 if options[:optimize].nil? || options[:optimize] != "false"
@@ -79,8 +104,6 @@ if options[:optimize].nil? || options[:optimize] != "false"
 else
   options[:optimize] = false
 end
-
-ALIAS_NAME = :term_search
 
 def index_ontology(indexed_ontologies, acronym, logger)
   begin
@@ -109,12 +132,32 @@ def index_ontology(indexed_ontologies, acronym, logger)
   end
 end
 
-if options[:all]
-  puts "You are about to create collection '#{options[:collection]}', re-index all ontologies into it, then swap the '#{ALIAS_NAME}' alias to point to it. Are you sure?"
+# --- Promote-only mode ---
+if options[:promote_only]
+  logger = Logger.new(options[:logfile])
+  collection = options[:collection]
+
+  puts "You are about to promote alias '#{ALIAS_NAME}' to point to collection '#{collection}'."
   puts "Type 'yes' to continue: "
   $stdout.flush
   confirm = $stdin.gets
-  abort("Aborting...\n\n") unless (confirm.strip == 'yes')
+  abort("Aborting...\n\n") unless confirm.strip == 'yes'
+
+  old_collection = Goo.promote_alias(ALIAS_NAME, collection)
+  msg = "Alias '#{ALIAS_NAME}' promoted from '#{old_collection}' to '#{collection}'."
+  puts msg
+  logger.info(msg)
+  exit
+end
+
+# --- Full re-index or individual ontology mode ---
+if options[:all]
+  action = options[:promote] ? "re-index all ontologies and promote alias" : "re-index all ontologies (no alias swap)"
+  puts "You are about to create collection '#{options[:collection]}' and #{action}. Are you sure?"
+  puts "Type 'yes' to continue: "
+  $stdout.flush
+  confirm = $stdin.gets
+  abort("Aborting...\n\n") unless confirm.strip == 'yes'
 end
 
 begin
@@ -165,15 +208,19 @@ begin
       logger.flush
     end
 
-    if options[:all]
-      logger.info("Swapping alias '#{ALIAS_NAME}' to collection '#{target_collection}'...")
-      Goo.complete_reindex(ALIAS_NAME)
-      logger.info("Alias swap complete.")
+    if options[:all] && options[:promote]
+      logger.info("Promoting alias '#{ALIAS_NAME}' to collection '#{target_collection}'...")
+      Goo.promote_alias(ALIAS_NAME, target_collection)
+      logger.info("Alias promotion complete.")
     end
   end
 
   if options[:all]
-    msg = "Completed full re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias '#{ALIAS_NAME}' now points to '#{options[:collection]}'."
+    if options[:promote]
+      msg = "Completed full re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias '#{ALIAS_NAME}' now points to '#{options[:collection]}'."
+    else
+      msg = "Completed full re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias NOT promoted — use --promote-only -c #{options[:collection]} to promote later."
+    end
   else
     msg = "Completed processing index for ontologies: #{indexed_ontologies} in #{(time/60).round(1)} minutes."
   end

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -23,24 +23,18 @@ elsif LinkedData.settings.goo_host.include? "prod"
 end
 puts "Running on #{platform} platform"
 
-require 'uri'
 require 'benchmark'
 require 'optparse'
 
 options = {all: false}
 opt_parser = OptionParser.new do |opts|
-  # Set a banner, displayed at the top of the help screen.
-  #opts.banner = "Usage: ncbo_ontology_index [options]"
-
-  opts.on('-c', '--solr-core-url URL', 'Optional URL of the Solr core to be used for indexing. Ex: http://localhost:8983/solr/core1') do |url|
-    options[:solr_core_url] = url
+  opts.on('-c', '--collection NAME', 'Collection name to index into (required with -a). A new collection is created, indexed, then the alias is swapped to it.') do |name|
+    options[:collection] = name
   end
 
   options[:ontologies] = []
   opts.on('-a', '--all-ontologies', 'Index all ontologies (this or -o option required).') do
-    options[:solr_core_url] = NcboCron.settings.search_index_all_url if (options[:solr_core_url].nil?)
-
-    LinkedData::Models::Ontology.all.each  do |ont|
+    LinkedData::Models::Ontology.all.each do |ont|
       ont.bring(:acronym)
       options[:ontologies].push(ont.acronym)
     end
@@ -60,11 +54,6 @@ opt_parser = OptionParser.new do |opts|
     options[:logfile] = filename
   end
 
-  #options[:verbose] = false
-  #opts.on( '-v', '--verbose', 'Output more information' ) do
-  #  options[:verbose] = true
-  #end
-
   # Display the help screen, all programs are assumed to have this option.
   opts.on( '-h', '--help', 'Display this screen' ) do
     puts opts
@@ -79,13 +68,19 @@ unless options[:ontologies]
   puts opt_parser.help
   exit(1)
 end
-options[:solr_core_url] = LinkedData.settings.search_server_url if (options[:solr_core_url].nil?)
+
+if options[:all] && options[:collection].nil?
+  abort("Error: -c (collection name) is required when using -a (all ontologies).\n" \
+        "Example: #{$0} -a -c term_search_20260413\n\n")
+end
 
 if options[:optimize].nil? || options[:optimize] != "false"
   options[:optimize] = true
 else
   options[:optimize] = false
 end
+
+ALIAS_NAME = :term_search
 
 def index_ontology(indexed_ontologies, acronym, logger)
   begin
@@ -114,20 +109,8 @@ def index_ontology(indexed_ontologies, acronym, logger)
   end
 end
 
-def valid_url?(url)
-  url = URI.parse(url) rescue false
-  url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS)
-end
-
-abort("The Solr core URL you provided is invalid. Aborting...\n\n") unless valid_url?(options[:solr_core_url])
-
-if options[:all] && options[:solr_core_url].downcase == LinkedData.settings.search_server_url.downcase
-  puts "WARNING: You are about to clear the main core search index on #{options[:solr_core_url]}!!! This will affect ALL searches!!! Are you sure you mean to do this?"
-elsif options[:all]
-  puts "You are about to clear the index on #{options[:solr_core_url]} and kick off a lengthy re-indexing process. Are you sure?"
-end
-
 if options[:all]
+  puts "You are about to create collection '#{options[:collection]}', re-index all ontologies into it, then swap the '#{ALIAS_NAME}' alias to point to it. Are you sure?"
   puts "Type 'yes' to continue: "
   $stdout.flush
   confirm = $stdin.gets
@@ -137,18 +120,24 @@ end
 begin
   logger = Logger.new(options[:logfile])
   puts "Processing details are logged to #{options[:logfile] == STDOUT ? "STDOUT" : options[:logfile]}"
-  msg = ""
 
   if options[:all]
-    msg = "Processing index for all ontologies on #{options[:solr_core_url]}"
-  else
-    msg = "Processing index for ontologies: #{options[:ontologies]} on #{options[:solr_core_url]}"
-  end
-  puts msg
-  logger.info(msg)
+    msg = "Processing full re-index for all ontologies into collection '#{options[:collection]}'"
+    puts msg
+    logger.info(msg)
 
-  Goo.configure do |conf|
-    conf.add_search_backend(:main, service: options[:solr_core_url])
+    # Create a new collection for re-indexing
+    logger.info("Creating reindex collection '#{options[:collection]}'...")
+    reindex_conn = Goo.create_reindex_connection(ALIAS_NAME, options[:collection])
+    target_collection = reindex_conn.collection_name
+
+    logger.info("Clearing new collection '#{target_collection}'...")
+    LinkedData::Models::Class.indexClear(target_collection)
+    LinkedData::Models::Class.indexCommit(nil, target_collection)
+  else
+    msg = "Processing index for ontologies: #{options[:ontologies]}"
+    puts msg
+    logger.info(msg)
   end
 
   indexed_ontologies = []
@@ -156,12 +145,6 @@ begin
 
   time = Benchmark.realtime do
     logger.info("There is a total of #{options[:ontologies].length} ontolog#{options[:ontologies].length > 1 ? "ies" : "y"} to index")
-
-    if options[:all]
-      logger.info("Clearing existing index on #{options[:solr_core_url]}")
-      LinkedData::Models::Class.indexClear()
-      LinkedData::Models::Class.indexCommit()
-    end
 
     options[:ontologies].each do |acronym|
       index_ontology(indexed_ontologies, acronym, logger)
@@ -173,16 +156,26 @@ begin
       logger.info("Optimizing index...")
       logger.flush
       t0 = Time.now
-      LinkedData::Models::Class.indexOptimize()
+      if options[:all]
+        LinkedData::Models::Class.indexOptimize(nil, target_collection)
+      else
+        LinkedData::Models::Class.indexOptimize()
+      end
       logger.info("Completed optimizing index in #{Time.now - t0} sec.")
       logger.flush
+    end
+
+    if options[:all]
+      logger.info("Swapping alias '#{ALIAS_NAME}' to collection '#{target_collection}'...")
+      Goo.complete_reindex(ALIAS_NAME)
+      logger.info("Alias swap complete.")
     end
   end
 
   if options[:all]
-    msg = "Completed processing index for all ontologies on #{options[:solr_core_url]} in #{(time/60).round(1)} minutes."
+    msg = "Completed full re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias '#{ALIAS_NAME}' now points to '#{options[:collection]}'."
   else
-    msg = "Completed processing index for ontologies: #{indexed_ontologies} on #{options[:solr_core_url]} in #{(time/60).round(1)} minutes."
+    msg = "Completed processing index for ontologies: #{indexed_ontologies} in #{(time/60).round(1)} minutes."
   end
   puts msg
   logger.info(msg)

--- a/bin/ncbo_ontology_property_index
+++ b/bin/ncbo_ontology_property_index
@@ -26,14 +26,13 @@ puts "Running on #{platform} platform"
 require 'benchmark'
 require 'optparse'
 
+ALIAS_NAME = :prop_search
+
 options = {all: false}
 opt_parser = OptionParser.new do |opts|
-  opts.on('-c', '--collection NAME', 'Collection name to index into (required with -a). A new collection is created, indexed, then the alias is swapped to it.') do |name|
-    options[:collection] = name
-  end
+  opts.banner = "Usage: #{$0} [options]"
 
-  options[:ontologies] = []
-  opts.on('-a', '--all-ontologies', 'Index all ontologies properties (this or -o option required).') do
+  opts.on('-a', '--all-ontologies', 'Index all ontology properties (this or -o option required, unless using --promote-only).') do
     LinkedData::Models::Ontology.all.each do |ont|
       ont.bring(:acronym)
       options[:ontologies].push(ont.acronym)
@@ -41,37 +40,63 @@ opt_parser = OptionParser.new do |opts|
     options[:all] = true
   end
 
-  opts.on('-o', '--ontologies ACRONYM1,ACRONYM2,ACRONYM3', 'Comma-separated list of ontologies whose properties to index (this or -a option required).') do |acronyms|
+  opts.on('-o', '--ontologies ACRONYM1,ACRONYM2,ACRONYM3', 'Comma-separated list of ontologies whose properties to index.') do |acronyms|
     options[:ontologies] = acronyms.split(",").map {|o| o.strip}
   end
 
-  opts.on('-z', '--optimize [true/false]', 'Whether to optimize the property index after the indexing completion. Default: true') do |optimize|
+  opts.on('-c', '--collection NAME', 'Target collection name (required with -a and --promote-only).') do |name|
+    options[:collection] = name
+  end
+
+  opts.on('-p', '--promote', 'Promote the alias to the new collection after successful indexing. Use with -a -c.') do
+    options[:promote] = true
+  end
+
+  opts.on('--promote-only', 'Promote the alias to an existing collection without rebuilding. Requires -c.') do
+    options[:promote_only] = true
+  end
+
+  opts.on('-z', '--optimize [true/false]', 'Whether to optimize the property index after indexing. Default: true') do |optimize|
     options[:optimize] = optimize
   end
 
   options[:logfile] = STDOUT
-  opts.on( '-l', '--logfile FILE', "Write log to FILE (default is STDOUT)" ) do |filename|
+  opts.on('-l', '--logfile FILE', "Write log to FILE (default is STDOUT)") do |filename|
     options[:logfile] = filename
   end
 
-  # Display the help screen, all programs are assumed to have this option.
-  opts.on( '-h', '--help', 'Display this screen' ) do
+  opts.on('-h', '--help', 'Display this screen') do
     puts opts
+    puts
+    puts "Examples:"
+    puts "  Rebuild all into a new collection (no alias swap):"
+    puts "    #{$0} -a -c prop_search_rebuild"
+    puts
+    puts "  Rebuild all and promote alias on success:"
+    puts "    #{$0} -a -c prop_search_20260401 -p"
+    puts
+    puts "  Promote alias to an existing collection (no rebuild):"
+    puts "    #{$0} --promote-only -c prop_search_20260401"
+    puts
+    puts "  Re-index specific ontologies into the live alias:"
+    puts "    #{$0} -o SNOMEDCT,GO"
     exit
   end
 end
 
-# Parse the command-line. The 'parse' method simply parses ARGV, while the 'parse!' method parses ARGV and removes
-# any options found there, as well as any parameters for the options.
+options[:ontologies] = []
 opt_parser.parse!
-unless options[:ontologies]
+
+# Validate option combinations
+if options[:promote_only]
+  abort("Error: -c (collection name) is required with --promote-only.\n\n") if options[:collection].nil?
+  abort("Error: --promote-only cannot be combined with -a or -o.\n\n") if options[:all] || !options[:ontologies].empty?
+elsif options[:all]
+  abort("Error: -c (collection name) is required when using -a.\n" \
+        "Example: #{$0} -a -c prop_search_20260413\n\n") if options[:collection].nil?
+elsif options[:ontologies].empty?
   puts opt_parser.help
   exit(1)
-end
-
-if options[:all] && options[:collection].nil?
-  abort("Error: -c (collection name) is required when using -a (all ontologies).\n" \
-        "Example: #{$0} -a -c prop_search_20260413\n\n")
 end
 
 if options[:optimize].nil? || options[:optimize] != "false"
@@ -79,8 +104,6 @@ if options[:optimize].nil? || options[:optimize] != "false"
 else
   options[:optimize] = false
 end
-
-ALIAS_NAME = :prop_search
 
 def index_ontology_properties(indexed_ontologies, acronym, logger)
   begin
@@ -103,16 +126,37 @@ def index_ontology_properties(indexed_ontologies, acronym, logger)
     indexed_ontologies << acronym
   rescue Exception => e
     msg = "Exception: #{e.class}: #{e.message}\n#{e.backtrace.join("\n")}"
+    puts msg
     logger.error(msg)
   end
 end
 
-if options[:all]
-  puts "You are about to create collection '#{options[:collection]}', re-index all ontology properties into it, then swap the '#{ALIAS_NAME}' alias to point to it. Are you sure?"
+# --- Promote-only mode ---
+if options[:promote_only]
+  logger = Logger.new(options[:logfile])
+  collection = options[:collection]
+
+  puts "You are about to promote alias '#{ALIAS_NAME}' to point to collection '#{collection}'."
   puts "Type 'yes' to continue: "
   $stdout.flush
   confirm = $stdin.gets
-  abort("Aborting...\n\n") unless (confirm.strip == 'yes')
+  abort("Aborting...\n\n") unless confirm.strip == 'yes'
+
+  old_collection = Goo.promote_alias(ALIAS_NAME, collection)
+  msg = "Alias '#{ALIAS_NAME}' promoted from '#{old_collection}' to '#{collection}'."
+  puts msg
+  logger.info(msg)
+  exit
+end
+
+# --- Full re-index or individual ontology mode ---
+if options[:all]
+  action = options[:promote] ? "re-index all ontology properties and promote alias" : "re-index all ontology properties (no alias swap)"
+  puts "You are about to create collection '#{options[:collection]}' and #{action}. Are you sure?"
+  puts "Type 'yes' to continue: "
+  $stdout.flush
+  confirm = $stdin.gets
+  abort("Aborting...\n\n") unless confirm.strip == 'yes'
 end
 
 begin
@@ -163,15 +207,19 @@ begin
       logger.flush
     end
 
-    if options[:all]
-      logger.info("Swapping alias '#{ALIAS_NAME}' to collection '#{target_collection}'...")
-      Goo.complete_reindex(ALIAS_NAME)
-      logger.info("Alias swap complete.")
+    if options[:all] && options[:promote]
+      logger.info("Promoting alias '#{ALIAS_NAME}' to collection '#{target_collection}'...")
+      Goo.promote_alias(ALIAS_NAME, target_collection)
+      logger.info("Alias promotion complete.")
     end
   end
 
   if options[:all]
-    msg = "Completed full property re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias '#{ALIAS_NAME}' now points to '#{options[:collection]}'."
+    if options[:promote]
+      msg = "Completed full property re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias '#{ALIAS_NAME}' now points to '#{options[:collection]}'."
+    else
+      msg = "Completed full property re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias NOT promoted — use --promote-only -c #{options[:collection]} to promote later."
+    end
   else
     msg = "Completed processing property index for ontologies: #{indexed_ontologies} in #{(time/60).round(1)} minutes."
   end

--- a/bin/ncbo_ontology_property_index
+++ b/bin/ncbo_ontology_property_index
@@ -23,21 +23,18 @@ elsif LinkedData.settings.goo_host.include? "prod"
 end
 puts "Running on #{platform} platform"
 
-require 'uri'
 require 'benchmark'
 require 'optparse'
 
 options = {all: false}
 opt_parser = OptionParser.new do |opts|
-  opts.on('-c', '--solr-core-url URL', 'Optional URL of the Solr core to be used for property indexing. Ex: http://localhost:8983/solr/prop_search_core1') do |url|
-    options[:solr_core_url] = url
+  opts.on('-c', '--collection NAME', 'Collection name to index into (required with -a). A new collection is created, indexed, then the alias is swapped to it.') do |name|
+    options[:collection] = name
   end
 
   options[:ontologies] = []
   opts.on('-a', '--all-ontologies', 'Index all ontologies properties (this or -o option required).') do
-    options[:solr_core_url] = NcboCron.settings.property_search_index_all_url if (options[:solr_core_url].nil?)
-
-    LinkedData::Models::Ontology.all.each  do |ont|
+    LinkedData::Models::Ontology.all.each do |ont|
       ont.bring(:acronym)
       options[:ontologies].push(ont.acronym)
     end
@@ -72,12 +69,18 @@ unless options[:ontologies]
   exit(1)
 end
 
-options[:solr_core_url] = LinkedData.settings.property_search_server_url if (options[:solr_core_url].nil?)
+if options[:all] && options[:collection].nil?
+  abort("Error: -c (collection name) is required when using -a (all ontologies).\n" \
+        "Example: #{$0} -a -c prop_search_20260413\n\n")
+end
+
 if options[:optimize].nil? || options[:optimize] != "false"
   options[:optimize] = true
 else
   options[:optimize] = false
 end
+
+ALIAS_NAME = :prop_search
 
 def index_ontology_properties(indexed_ontologies, acronym, logger)
   begin
@@ -104,20 +107,8 @@ def index_ontology_properties(indexed_ontologies, acronym, logger)
   end
 end
 
-def valid_url?(url)
-  url = URI.parse(url) rescue false
-  url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS)
-end
-
-abort("The Solr core URL you provided is invalid. Aborting...\n\n") unless valid_url?(options[:solr_core_url])
-
-if options[:all] && options[:solr_core_url].downcase == LinkedData.settings.property_search_server_url.downcase
-  puts "WARNING: You are about to clear the main core property search index on #{options[:solr_core_url]}!!! This will affect ALL property searches!!! Are you sure you mean to do this?"
-elsif options[:all]
-  puts "You are about to clear the property index on #{options[:solr_core_url]} and kick off a full re-indexing process. Are you sure?"
-end
-
 if options[:all]
+  puts "You are about to create collection '#{options[:collection]}', re-index all ontology properties into it, then swap the '#{ALIAS_NAME}' alias to point to it. Are you sure?"
   puts "Type 'yes' to continue: "
   $stdout.flush
   confirm = $stdin.gets
@@ -127,18 +118,24 @@ end
 begin
   logger = Logger.new(options[:logfile])
   puts "Processing details are logged to #{options[:logfile] == STDOUT ? "STDOUT" : options[:logfile]}"
-  msg = ""
 
   if options[:all]
-    msg = "Processing property index for all ontologies on #{options[:solr_core_url]}"
-  else
-    msg = "Processing property index for ontologies: #{options[:ontologies]} on #{options[:solr_core_url]}"
-  end
-  puts msg
-  logger.info(msg)
+    msg = "Processing full property re-index for all ontologies into collection '#{options[:collection]}'"
+    puts msg
+    logger.info(msg)
 
-  Goo.configure do |conf|
-    conf.add_search_backend(:property, service: options[:solr_core_url])
+    # Create a new collection for re-indexing
+    logger.info("Creating reindex collection '#{options[:collection]}'...")
+    reindex_conn = Goo.create_reindex_connection(ALIAS_NAME, options[:collection])
+    target_collection = reindex_conn.collection_name
+
+    logger.info("Clearing new collection '#{target_collection}'...")
+    LinkedData::Models::OntologyProperty.indexClear(target_collection)
+    LinkedData::Models::OntologyProperty.indexCommit(nil, target_collection)
+  else
+    msg = "Processing property index for ontologies: #{options[:ontologies]}"
+    puts msg
+    logger.info(msg)
   end
 
   indexed_ontologies = []
@@ -146,12 +143,6 @@ begin
 
   time = Benchmark.realtime do
     logger.info("There is a total of #{options[:ontologies].length} ontolog#{options[:ontologies].length > 1 ? "ies" : "y"} to index the properties of")
-
-    if options[:all]
-      logger.info("Clearing existing property index on #{options[:solr_core_url]}")
-      LinkedData::Models::Class.indexClear(:property)
-      LinkedData::Models::Class.indexCommit(nil, :property)
-    end
 
     options[:ontologies].each do |acronym|
       index_ontology_properties(indexed_ontologies, acronym, logger)
@@ -163,16 +154,26 @@ begin
       logger.info("Optimizing property index...")
       logger.flush
       t0 = Time.now
-      LinkedData::Models::Class.indexOptimize(nil, :property)
+      if options[:all]
+        LinkedData::Models::OntologyProperty.indexOptimize(nil, target_collection)
+      else
+        LinkedData::Models::OntologyProperty.indexOptimize()
+      end
       logger.info("Completed optimizing property index in #{Time.now - t0} sec.")
       logger.flush
+    end
+
+    if options[:all]
+      logger.info("Swapping alias '#{ALIAS_NAME}' to collection '#{target_collection}'...")
+      Goo.complete_reindex(ALIAS_NAME)
+      logger.info("Alias swap complete.")
     end
   end
 
   if options[:all]
-    msg = "Completed processing property index for all ontologies on #{options[:solr_core_url]} in #{(time/60).round(1)} minutes."
+    msg = "Completed full property re-index into '#{options[:collection]}' in #{(time/60).round(1)} minutes. Alias '#{ALIAS_NAME}' now points to '#{options[:collection]}'."
   else
-    msg = "Completed processing property index for ontologies: #{indexed_ontologies} on #{options[:solr_core_url]} in #{(time/60).round(1)} minutes."
+    msg = "Completed processing property index for ontologies: #{indexed_ontologies} in #{(time/60).round(1)} minutes."
   end
   puts msg
   logger.info(msg)

--- a/bin/ncbo_search_aliases
+++ b/bin/ncbo_search_aliases
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+
+# Exit cleanly from an early interrupt
+Signal.trap("INT") { exit 1 }
+
+# Setup the bundled gems in our environment
+require 'bundler/setup'
+
+# Configure the process for the current cron configuration.
+require_relative '../lib/ncbo_cron'
+config_exists = File.exist?(File.expand_path('../../config/config.rb', __FILE__))
+abort("Please create a config/config.rb file using the config/config.rb.sample as a template") unless config_exists
+require_relative '../config/config'
+
+ALIASES = {
+  term_search: "Term/class search",
+  prop_search: "Property search"
+}
+
+puts "SolrCloud Alias Status"
+puts "=" * 50
+
+ALIASES.each do |alias_name, description|
+  connector = Goo.search_client(alias_name)
+
+  if connector.nil?
+    puts "\n#{description} (#{alias_name}): NOT CONFIGURED"
+    next
+  end
+
+  puts "\n#{description}"
+  puts "-" * 40
+
+  if connector.aliased?
+    collection = connector.collection_name
+    puts "  Alias:      #{alias_name}"
+    puts "  Collection: #{collection}"
+  else
+    puts "  Collection: #{connector.collection_name} (no alias)"
+  end
+end
+
+puts

--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -66,8 +66,11 @@ NcboCron.config do |config|
   # do not deaemonize in docker
   config.daemonize  = false
 
-  config.search_index_all_url = "http://localhost:8983/solr"
-  config.property_search_index_all_url = "http://localhost:8983/solr"
+  # Note: search_index_all_url and property_search_index_all_url have been removed.
+  # Full re-indexing now uses SolrCloud aliases. Use the -c flag on the index scripts
+  # to specify the target collection name, e.g.:
+  #   ./bin/ncbo_ontology_index -a -c term_search_20260413
+  #   ./bin/ncbo_ontology_property_index -a -c prop_search_20260413
 
   # Sample configuration for Cloudflare Analytics integration
   # Cloudflare Zone Tag (unique identifier for your Cloudflare zone)


### PR DESCRIPTION
## Summary

Reworks `ncbo_ontology_index` and `ncbo_ontology_property_index` to use the new SolrCloud alias re-index workflow, adds flexible alias promotion flags, and introduces an `ncbo_search_aliases` inspection script.

## Prerequisites

This PR depends on changes introduced in:

- https://github.com/ncbo/goo/pull/180
- https://github.com/ncbo/ontologies_linked_data/pull/280

### Changes

**`bin/ncbo_ontology_index`** and **`bin/ncbo_ontology_property_index`**

Both scripts now support three workflows via new CLI flags:

| Flags | Behavior |
|---|---|
| `-a -c NAME` | Rebuild all into a new collection (no alias swap) |
| `-a -c NAME -p` | Rebuild all, then promote alias on success |
| `--promote-only -c NAME` | Promote alias to an existing collection without rebuilding |

- `-c` is required with `-a` (full re-index must target an explicit collection name)
- `-o` (individual ontologies) continues to index directly into the live alias, unchanged
- Both scripts use `Goo.promote_alias` instead of `Goo.complete_reindex`, preserving the old collection for rollback

**`bin/ncbo_search_aliases`** (new)

Inspection script that reports the current state of `term_search` and `prop_search` aliases and their backing collections.

**`config/config.rb.sample`**

Removed obsolete `search_index_all_url` and `property_search_index_all_url` settings, replaced with a comment explaining the new `-c` flag usage.

## Test plan

- [ ] `ncbo_ontology_index -h` and `ncbo_ontology_property_index -h` display updated help with examples
- [ ] `ncbo_ontology_index -a -c term_search_test` creates collection, indexes, does not swap alias
- [ ] `ncbo_ontology_index --promote-only -c term_search_test` swaps alias without rebuilding
- [ ] `ncbo_ontology_index -a -c term_search_test -p` creates, indexes, and swaps alias on success
- [ ] `ncbo_ontology_index -o SNOMEDCT` indexes into live alias (existing behavior)
- [ ] `ncbo_search_aliases` reports correct alias → collection mappings
- [ ] Validate the same workflows for `ncbo_ontology_property_index`
