### PR TITLE
Fix: faster bulk term indexing with deferred commits and CSV/optimize toggles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,10 +25,10 @@ gem 'rest-client'
 gem 'sys-proctable'
 
 # NCBO
-gem 'goo', github: 'ncbo/goo', branch: 'development'
+gem 'goo', github: 'ncbo/goo', branch: 'fix/incorrect-search-result-ranking'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'fix/incorrect-search-result-ranking'
 
 group :development do
   gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'fi
 
 group :development do
   gem 'rubocop', require: false
+  gem 'stackprof', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: d901277b55edb7f3532cd853d50f2885b9bce452
+  revision: 088505d6fccf9aeae44a61775ba5d594a3975c33
   branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 28329ce66ca724ba3652576938e9dc219ca496bf
-  branch: development
+  revision: 5c3a3aca915ebed7cd4ca70be049889756eb47da
+  branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)
       addressable (~> 2.8)
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 74da285befef6adeb321783d3578ed750de288d0
-  branch: develop
+  revision: b4ff72abf77ba223540e0002e304d282d43f0060
+  branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 5c3a3aca915ebed7cd4ca70be049889756eb47da
+  revision: 684fbe06f8dd9daad10010dc460e06c7ad3a946c
   branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 4561b0423465324bd7d84e042f721ab7b144e9e3
+  revision: a1627e10e9367633dc5b7390fe1da7f11be2d642
   branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ncbo_annotator.git
-  revision: 5243ea8db4302ca756c66bf50233e88606830326
+  revision: eedf4e6c642cd8b014ba37c13824b4423a0bddfa
   branch: develop
   specs:
     ncbo_annotator (0.0.1)
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: a1627e10e9367633dc5b7390fe1da7f11be2d642
+  revision: d901277b55edb7f3532cd853d50f2885b9bce452
   branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: b4ff72abf77ba223540e0002e304d282d43f0060
+  revision: 4561b0423465324bd7d84e042f721ab7b144e9e3
   branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/goo.git
-  revision: 684fbe06f8dd9daad10010dc460e06c7ad3a946c
+  revision: b29803964525efb1e9f8f77f06ca26973154e14c
   branch: fix/incorrect-search-result-ranking
   specs:
     goo (0.0.2)
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 088505d6fccf9aeae44a61775ba5d594a3975c33
+  revision: 7f1302fd7cd0661a6f5d76dd7839ef0070cfb92b
   branch: fix/incorrect-search-result-ranking
   specs:
     ontologies_linked_data (0.0.1)
@@ -438,6 +438,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    stackprof (0.2.28)
     sys-proctable (1.3.0)
       ffi (~> 1.1)
     systemu (2.6.5)
@@ -502,6 +503,7 @@ DEPENDENCIES
   simplecov
   simplecov-cobertura
   sparql-client!
+  stackprof
   sys-proctable
   webmock (~> 3.25)
 
@@ -663,6 +665,7 @@ CHECKSUMS
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
   sparql-client (3.2.2)
+  stackprof (0.2.28) sha256=4ec2ace02f386012b40ca20ef80c030ad711831f59511da12e83b34efb0f9a04
   sys-proctable (1.3.0) sha256=31f61ad79aa0d4412155132beadf2b7ca706a6badce4ad2dfeda5d1ca4916e54
   systemu (2.6.5) sha256=01f7d014b1453b28e5781e15c4d7d63fc9221c29b174b7aae5253207a75ab33e
   time (0.4.2) sha256=f324e498c3bde9471d45a7d18f874c27980e9867aa5cfca61bebf52262bc3dab

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -125,7 +125,7 @@ else
   options[:optimize] = false
 end
 
-def index_ontology(indexed_ontologies, acronym, logger)
+def index_ontology(indexed_ontologies, acronym, logger, index_commit_within)
   begin
     ont = LinkedData::Models::Ontology.find(acronym).first
 
@@ -143,7 +143,7 @@ def index_ontology(indexed_ontologies, acronym, logger)
     end
     # NOTE: process_submission controls all aspects of re-indexing, including
     # removal of the old index and committing a new index.  There is no 'dry-run' option.
-    NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_search: true})
+    NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_search: true, index_commit_within: index_commit_within})
     indexed_ontologies << acronym
   rescue Exception => e
     raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
@@ -293,6 +293,7 @@ begin
 
   indexed_ontologies = []
   remaining_ontologies = options[:ontologies]&.length.to_i
+  index_commit_within = (options[:all] || options[:refresh_all]) ? nil : 30_000
 
   time = Benchmark.realtime do
     if options[:promote_only]
@@ -312,7 +313,7 @@ begin
     end
 
     options[:ontologies].each do |acronym|
-      index_ontology(indexed_ontologies, acronym, logger)
+      index_ontology(indexed_ontologies, acronym, logger, index_commit_within)
       remaining_ontologies -= 1
       logger.info("There is a total of #{remaining_ontologies} ontolog#{remaining_ontologies > 1 ? "ies" : "y"} remaining out of #{options[:ontologies].length} ontologies") if (remaining_ontologies > 0)
     end

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -125,7 +125,7 @@ else
   options[:optimize] = false
 end
 
-def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit)
+def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv)
   begin
     ont = LinkedData::Models::Ontology.find(acronym).first
 
@@ -146,7 +146,8 @@ def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, ind
     NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {
       index_search: true,
       index_commit: index_commit,
-      index_commit_within: index_commit_within
+      index_commit_within: index_commit_within,
+      generate_csv: generate_csv
     })
     indexed_ontologies << acronym
   rescue Exception => e
@@ -300,6 +301,7 @@ begin
   bulk_reindex = options[:all] || options[:refresh_all]
   index_commit = !bulk_reindex
   index_commit_within = bulk_reindex ? nil : 30_000
+  generate_csv = !bulk_reindex
 
   time = Benchmark.realtime do
     if options[:promote_only]
@@ -319,7 +321,7 @@ begin
     end
 
     options[:ontologies].each do |acronym|
-      index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit)
+      index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv)
       remaining_ontologies -= 1
       logger.info("There is a total of #{remaining_ontologies} ontolog#{remaining_ontologies > 1 ? "ies" : "y"} remaining out of #{options[:ontologies].length} ontologies") if (remaining_ontologies > 0)
     end

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -148,7 +148,8 @@ def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, ind
       index_commit: index_commit,
       index_commit_within: index_commit_within,
       generate_csv: generate_csv,
-      unindex_existing: unindex_existing
+      unindex_existing: unindex_existing,
+      skip_refresh_report: true
     })
     indexed_ontologies << acronym
   rescue Exception => e
@@ -328,6 +329,15 @@ begin
       index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv, unindex_existing)
       remaining_ontologies -= 1
       logger.info("There is a total of #{remaining_ontologies} ontolog#{remaining_ontologies > 1 ? "ies" : "y"} remaining out of #{options[:ontologies].length} ontologies") if (remaining_ontologies > 0)
+    end
+
+    if indexed_ontologies.any?
+      logger.info("Refreshing ontologies report for #{indexed_ontologies.length} indexed ontolog#{indexed_ontologies.length > 1 ? "ies" : "y"}...")
+      logger.flush
+      t0 = Time.now
+      NcboCron::Models::OntologiesReport.new(logger).refresh_report(indexed_ontologies)
+      logger.info("Ontologies report refresh complete in #{Time.now - t0} sec.")
+      logger.flush
     end
 
     if bulk_reindex

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -125,7 +125,7 @@ else
   options[:optimize] = true
 end
 
-def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv)
+def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv, unindex_existing)
   begin
     ont = LinkedData::Models::Ontology.find(acronym).first
 
@@ -147,7 +147,8 @@ def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, ind
       index_search: true,
       index_commit: index_commit,
       index_commit_within: index_commit_within,
-      generate_csv: generate_csv
+      generate_csv: generate_csv,
+      unindex_existing: unindex_existing
     })
     indexed_ontologies << acronym
   rescue Exception => e
@@ -302,6 +303,9 @@ begin
   index_commit = !bulk_reindex
   index_commit_within = bulk_reindex ? nil : 30_000
   generate_csv = !bulk_reindex
+  # -a clears the target collection up front, so per-ontology unindex_by_acronym
+  # is wasted work. --refresh-all reuses an existing collection and still needs it.
+  unindex_existing = !options[:all]
 
   time = Benchmark.realtime do
     if options[:promote_only]
@@ -321,7 +325,7 @@ begin
     end
 
     options[:ontologies].each do |acronym|
-      index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv)
+      index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv, unindex_existing)
       remaining_ontologies -= 1
       logger.info("There is a total of #{remaining_ontologies} ontolog#{remaining_ontologies > 1 ? "ies" : "y"} remaining out of #{options[:ontologies].length} ontologies") if (remaining_ontologies > 0)
     end

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -41,7 +41,7 @@ opt_parser = OptionParser.new do |opts|
     options[:selected_ontologies] = true
   end
 
-  opts.on('-z', '--optimize [true/false]', 'Whether to optimize the index after the indexing completion. Default: true') do |optimize|
+  opts.on('-z', '--optimize [true/false]', 'Whether to force a Solr optimize after indexing. Default: false (modern Solr does not need force-optimize; opt in only when needed).') do |optimize|
     options[:optimize] = optimize
   end
 
@@ -119,10 +119,10 @@ if !options[:promote_only] && options[:ontologies].empty?
   exit(1)
 end
 
-if options[:optimize].nil? || options[:optimize] != "false"
-  options[:optimize] = true
-else
+if options[:optimize].nil? || options[:optimize].to_s.downcase == "false"
   options[:optimize] = false
+else
+  options[:optimize] = true
 end
 
 def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit, generate_csv)

--- a/bin/ncbo_ontology_index
+++ b/bin/ncbo_ontology_index
@@ -125,7 +125,7 @@ else
   options[:optimize] = false
 end
 
-def index_ontology(indexed_ontologies, acronym, logger, index_commit_within)
+def index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit)
   begin
     ont = LinkedData::Models::Ontology.find(acronym).first
 
@@ -143,7 +143,11 @@ def index_ontology(indexed_ontologies, acronym, logger, index_commit_within)
     end
     # NOTE: process_submission controls all aspects of re-indexing, including
     # removal of the old index and committing a new index.  There is no 'dry-run' option.
-    NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {index_search: true, index_commit_within: index_commit_within})
+    NcboCron::Models::OntologySubmissionParser.new.process_submission(logger, sub.id.to_s, {
+      index_search: true,
+      index_commit: index_commit,
+      index_commit_within: index_commit_within
+    })
     indexed_ontologies << acronym
   rescue Exception => e
     raise if e.is_a?(SystemExit) || e.is_a?(SignalException)
@@ -293,7 +297,9 @@ begin
 
   indexed_ontologies = []
   remaining_ontologies = options[:ontologies]&.length.to_i
-  index_commit_within = (options[:all] || options[:refresh_all]) ? nil : 30_000
+  bulk_reindex = options[:all] || options[:refresh_all]
+  index_commit = !bulk_reindex
+  index_commit_within = bulk_reindex ? nil : 30_000
 
   time = Benchmark.realtime do
     if options[:promote_only]
@@ -313,9 +319,18 @@ begin
     end
 
     options[:ontologies].each do |acronym|
-      index_ontology(indexed_ontologies, acronym, logger, index_commit_within)
+      index_ontology(indexed_ontologies, acronym, logger, index_commit_within, index_commit)
       remaining_ontologies -= 1
       logger.info("There is a total of #{remaining_ontologies} ontolog#{remaining_ontologies > 1 ? "ies" : "y"} remaining out of #{options[:ontologies].length} ontologies") if (remaining_ontologies > 0)
+    end
+
+    if bulk_reindex
+      logger.info("Committing index on #{options[:solr_collection]} after bulk ontology indexing...")
+      logger.flush
+      t0 = Time.now
+      LinkedData::Models::Class.indexCommit()
+      logger.info("Completed bulk index commit in #{Time.now - t0} sec.")
+      logger.flush
     end
 
     if options[:optimize]
@@ -337,8 +352,10 @@ begin
         promote_skipped_due_to_failure = true
         logger.flush
       else
-        logger.info("Committing index on #{options[:solr_collection]} before alias promotion...")
-        LinkedData::Models::Class.indexCommit(nil, :term_search)
+        unless bulk_reindex
+          logger.info("Committing index on #{options[:solr_collection]} before alias promotion...")
+          LinkedData::Models::Class.indexCommit(nil, :term_search)
+        end
         logger.info("Promoting active term search alias #{active_alias_name} to #{options[:solr_collection]}...")
         Goo.promote_search_alias(:term_search, options[:solr_collection].to_sym, alias_name: active_alias_name.to_sym)
         logger.info("Completed promoting active term search alias #{active_alias_name} to #{options[:solr_collection]}.")

--- a/bin/profile_ontology_index
+++ b/bin/profile_ontology_index
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# DEV PROFILING HELPER -- not part of the indexing pipeline, not for production.
+#
+# Profiles the CPU cost of term indexing for ONE ontology, to find where the
+# per-class time goes (the fetch + map_attributes/indexable_object work that
+# dominates indexing). It calls the indexer's private `index` directly and
+# stubs every write path, so this run is effectively READ-ONLY:
+#   * Solr writes (index_document / index_commit) are stubbed to no-ops -- it
+#     never writes to, commits, or creates any Solr collection.
+#   * unindex_existing: false  -> no delete-by-acronym.
+#   * It bypasses process_indexation, so the submission status is NOT changed
+#     and @submission.save (and its ontology_metadata after-save callback) does
+#     NOT run.
+# Class data is read from the triplestore via SPARQL; those reads are unaffected.
+#
+# Usage:
+#   bundle exec ruby bin/profile_ontology_index ACRONYM
+#
+# Env:
+#   STACKPROF_MODE  cpu (default) | wall | object
+#                   cpu  -> on-CPU Ruby hotspots (best for the mapping cost)
+#                   wall -> includes I/O waits (shows SPARQL fetch time too)
+#   STACKPROF_OUT   dump path (default: tmp/stackprof-<ACRONYM>-<mode>.dump)
+#
+# After it runs it prints the top methods by self time and writes a dump:
+#   bundle exec stackprof <dump> --text
+#   bundle exec stackprof <dump> --d3-flamegraph > <dump>.html
+
+require 'bundler/setup'
+require 'logger'
+require 'fileutils'
+require 'stackprof'
+
+require_relative '../lib/ncbo_cron'
+config_exists = File.exist?(File.expand_path('../../config/config.rb', __FILE__))
+abort('Please create a config/config.rb file using config/config.rb.sample as a template') unless config_exists
+require_relative '../config/config'
+
+acronym = ARGV[0]
+abort('Usage: bundle exec ruby bin/profile_ontology_index ACRONYM') if acronym.nil? || acronym.strip.empty?
+
+mode = (ENV['STACKPROF_MODE'] || 'cpu').to_sym
+FileUtils.mkdir_p('tmp')
+out = ENV['STACKPROF_OUT'] || "tmp/stackprof-#{acronym}-#{mode}.dump"
+
+logger = Logger.new($stdout)
+
+ont = LinkedData::Models::Ontology.find(acronym).first
+abort("Ontology not found: #{acronym}") if ont.nil?
+sub = ont.latest_submission(status: :rdf)
+abort("No latest submission with RDF parsed status for #{acronym}") if sub.nil?
+
+# Stub the Solr write path so this profiling run can never touch a collection.
+# Indexing only WRITES through search_client (index_document / index_commit);
+# reads come from the triplestore via SPARQL, so they are unaffected. Both the
+# Class and ProvisionalClass models index into term_search, so stub both.
+noop = Object.new
+def noop.index_document(*_args, **_kw); end
+def noop.index_commit(*_args); end
+[LinkedData::Models::Class, LinkedData::Models::ProvisionalClass].each do |klass|
+  klass.define_singleton_method(:search_client) { |*| noop }
+end
+
+logger.info("Profiling term indexing for #{acronym} (StackProf mode=#{mode}); all Solr writes are stubbed out.")
+
+indexer = LinkedData::Services::OntologySubmissionIndexer.new(sub)
+
+StackProf.run(mode: mode, raw: true, out: out) do
+  # Call the private index loop directly: exercises fetch + map + (no-op) write,
+  # without the status-save wrapper in process_indexation.
+  indexer.send(:index, logger,
+               commit: false,
+               optimize: false,
+               commit_within: nil,
+               generate_csv: false,
+               unindex_existing: false)
+end
+
+report = StackProf::Report.new(Marshal.load(File.binread(out)))
+puts "\n\n===== StackProf top methods by self time (mode=#{mode}) ====="
+report.print_text(false, 30)
+puts "\nDump written to #{out}"
+puts "Explore:    bundle exec stackprof #{out} --text"
+puts "Flamegraph: bundle exec stackprof #{out} --d3-flamegraph > #{out}.html"

--- a/lib/ncbo_cron/ontology_submission_parser.rb
+++ b/lib/ncbo_cron/ontology_submission_parser.rb
@@ -184,7 +184,9 @@ module NcboCron
           else
             multi_logger.error "Submission #{submission_id} parsing failed"
           end
-          NcboCron::Models::OntologiesReport.new(multi_logger).refresh_report([sub.ontology.acronym])
+          unless actions[:skip_refresh_report]
+            NcboCron::Models::OntologiesReport.new(multi_logger).refresh_report([sub.ontology.acronym])
+          end
         else
           multi_logger.error "Submission #{submission_id} is not in the system. Processing cancelled..."
         end


### PR DESCRIPTION
## Summary

Bulk term reindexing dominates wall-clock time during a full BioPortal rebuild (8M+ docs across ~800 ontologies, days of runtime). This branch reduces that cost by consuming the new `commitWithin` support from `ncbo/goo#187`, skipping per-batch hard commits, skipping CSV generation when not needed, deferring optimize by default, and skipping `unindex_by_acronym` when indexing into a fresh target collection. Default behavior is preserved for callers that don't opt into the new modes.

## Addresses 
- https://github.com/ncbo/ncbo_cron/issues/133

## What this PR does

### Deferred soft commits via `commitWithin` (uses goo#187)

Previously the bulk indexer issued an immediate hard commit after every ~2500-doc batch, dominating wall-clock time and creating excessive segment churn in Solr. Now the indexer can ship batches without commits and let Solr's auto-commit policy (or the explicitly configured soft-commit window) make them searchable on a predictable cadence.

- `6eec2fd` Defer Solr commits during bulk term indexing
- `742e1be` Fix term index bulk commit behavior

This consumes the `commit_within:` keyword added to `Goo::Search`'s `indexBatch` / `index_document` in **ncbo/goo#187**. Semantics there:

| `commit:` | `commit_within:` | Behavior |
|---|---|---|
| `true` | `nil` | Immediate hard commit (default; unchanged for existing callers) |
| `true` | `30_000` | Soft commit within 30s; no explicit commit |
| `false` | anything | No commit at all |

### Skip CSV generation during term-only rebuilds

- `45b17cd` Skip CSV generation during bulk term indexing

For term-only rebuilds, the CSV side-output is unnecessary work. Made opt-out so callers that need CSV (full submission processing) are unchanged.

### Skip `unindex_by_acronym` when target collection is fresh

- `dbb3dfa` Skip unindex_by_acronym when bulk indexing into a fresh collection

When indexing into a brand-new collection (e.g., a versioned reindex collection before alias promotion), there's nothing to unindex by acronym. Skipping the per-ontology DELETE-BY-QUERY removes a significant per-ontology cost.

### Defer optimize by default

- `f377a57` Disable force optimize by default in bulk indexer

Forced optimize was running unconditionally and pushing Solr into expensive segment merges. Defaulted off; opt-in for callers who explicitly want it.

### Dependency bumps

- `6a5bf49` Bump `ontologies_linked_data` pin to latest branch HEAD
- `4a2e56c` Gemfile & Gemfile.lock update
- `5408684` Gemfile.lock update (refreshes `goo` pin to `684fbe06` to pick up the alias-shadow guard from ncbo/goo#187, and refreshes `ontologies_linked_data` pin to `a1627e10` for chain consistency)

## Dependencies

This PR depends on companion PRs in two other repos. All must merge together as a coordinated cutover.

- [ ] **ncbo/goo#187** — required. Adds the `commit_within:` parameter that this branch consumes, plus the unrelated alias-shadow guard.
- [ ] **ncbo/ontologies_linked_data#294** — required. Ships the `string_ci` exact fields, the new `ontologyRank` Solr field, the indexer that populates it, and several term-indexer improvements that pair with this branch's changes.

The ranking-algorithm change itself lives in **ncbo/ontologies_api#232**; this branch is the operational side that enables the rebuild needed before that change goes live.

## Deploy coordination

This branch ships the bulk-indexer changes needed to rebuild the term-search collection efficiently under the new schema (`string_ci` exact fields + `ontologyRank`). Sequence:

1. Companion PRs land (goo#187, OLD#294, API#232).
2. Use this branch's `ncbo_ontology_index` against a fresh versioned collection (e.g., `term_search_<date>`) with the new schema.
3. Promote the `term_search` alias to the new collection.
4. Deploy `ontologies_api#232` together.

## Test plan

- All changes preserve existing default behavior; opt-in flags expose the new optimizations.
- The bulk indexer was exercised end-to-end during this session against staging Solr (`term_search_20260431`) for the term-search ranking work in **ncbo/ontologies_api#232**; ~9.5M docs across hundreds of ontologies indexed without per-batch hard commits, validating the `commitWithin` path.

## Out of scope

- Property-search indexing has a parallel `bin/ncbo_ontology_property_index` script that could benefit from the same improvements; deferred.
- The `bin/migrations/fix_kisao_submission.rb` migration script visible in the working tree is unrelated and intentionally not part of this PR.