### PR TITLE
Feature: propagate ontology rank to Solr during the weekly rank job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,7 @@ gem 'sys-proctable'
 gem 'goo', github: 'ncbo/goo', branch: 'development'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
-# TEMP: tracking the rank-propagator working branch for staging validation.
-# REVERT to branch: 'develop' before merging this PR (after feature/rank-propagator merges to OLD develop).
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'feature/rank-propagator'
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
 
 group :development do
   gem 'rubocop', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,9 @@ gem 'sys-proctable'
 gem 'goo', github: 'ncbo/goo', branch: 'development'
 gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem 'ncbo_annotator', github: 'ncbo/ncbo_annotator', branch: 'develop'
-gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'develop'
+# TEMP: tracking the rank-propagator working branch for staging validation.
+# REVERT to branch: 'develop' before merging this PR (after feature/rank-propagator merges to OLD develop).
+gem 'ontologies_linked_data', github: 'ncbo/ontologies_linked_data', branch: 'feature/rank-propagator'
 
 group :development do
   gem 'rubocop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: c36ef753ef567d2a4001f83ebc8ff20a4544423d
+  revision: e559fe9cf97fb6c7fcc061420b1ecc652b6a3de5
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)
@@ -264,7 +264,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    json (2.19.9)
+    json (2.20.0)
     json-canonicalization (1.0.0)
     json-ld (3.3.2)
       htmlentities (~> 4.3)
@@ -584,7 +584,7 @@ CHECKSUMS
   http-cookie (1.1.6) sha256=ba4b82be64de61dc281243dac70e3c382c45142f20268ed9276a3670c93feaa9
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   json-canonicalization (1.0.0) sha256=d4848a8cca7534455c6721f2d9fc9e5e9adca49486864a898810024f67d59446
   json-ld (3.3.2) sha256=b9531893bf5bdc01db428e96953845a23adb1097125ce918ae0f97c4a6e1ab27
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GIT
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
   revision: e559fe9cf97fb6c7fcc061420b1ecc652b6a3de5
-  branch: develop
+  branch: feature/rank-propagator
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: e559fe9cf97fb6c7fcc061420b1ecc652b6a3de5
-  branch: feature/rank-propagator
+  revision: c6f83eba9c21513c60977f93f93c6f08af958921
+  branch: develop
   specs:
     ontologies_linked_data (0.0.1)
       activesupport

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 6bfd79d84b04b38a1a5ae44d241d216bc55a6435
+  revision: c3a52dfdd0278859a5968b9f5668c5fcd427f854
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: 752e7dfeea06fa91e076447acb9dbd8420894523
+  revision: e1349d0b936dbaee2a9bcebb77198f6e1a50db6b
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)
@@ -110,7 +110,7 @@ GEM
     childprocess (5.1.0)
       logger (~> 1.5)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -130,7 +130,7 @@ GEM
       mail (~> 2.7)
     et-orbi (1.4.0)
       tzinfo
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -261,10 +261,10 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    i18n (1.14.8)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    json (2.19.7)
+    json (2.19.9)
     json-canonicalization (1.0.0)
     json-ld (3.3.2)
       htmlentities (~> 4.3)
@@ -321,7 +321,7 @@ GEM
       uri (>= 0.11.1)
     net-http-persistent (4.0.8)
       connection_pool (>= 2.2.4, < 4)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -331,7 +331,7 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     netrc (0.11.0)
-    oj (3.17.1)
+    oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     omni_logger (0.1.4)
@@ -382,7 +382,7 @@ GEM
       reline
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.29.0)
+    redis-client (0.30.0)
       connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -420,7 +420,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby-xxHash (0.4.0.2)
     ruby2_keywords (0.0.5)
-    rubyzip (3.3.1)
+    rubyzip (3.4.0)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
     securerandom (0.4.1)
@@ -519,7 +519,7 @@ CHECKSUMS
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   dante (0.2.0) sha256=939776f04b4d253ffbbcf53341631aa2ee6e6cf314dedade2e60ac43b40a6fe6
@@ -531,7 +531,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   email_spec (2.3.1) sha256=5e8891319427fd6de0f3883dffe3c2ac4f5434359a33ed9c48e6d68e9f712f1b
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
-  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
@@ -582,9 +582,9 @@ CHECKSUMS
   htmlentities (4.4.2) sha256=bbafbdf69f2eca9262be4efef7e43e6a1de54c95eb600f26984f71d2fe96c5c3
   http-accept (1.7.0) sha256=c626860682bfbb3b46462f8c39cd470fd7b0584f61b3cc9df5b2e9eb9972a126
   http-cookie (1.1.6) sha256=ba4b82be64de61dc281243dac70e3c382c45142f20268ed9276a3670c93feaa9
-  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   json-canonicalization (1.0.0) sha256=d4848a8cca7534455c6721f2d9fc9e5e9adca49486864a898810024f67d59446
   json-ld (3.3.2) sha256=b9531893bf5bdc01db428e96953845a23adb1097125ce918ae0f97c4a6e1ab27
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
@@ -611,12 +611,12 @@ CHECKSUMS
   net-ftp (0.3.9) sha256=307817ccf7f428f79d083f7e36dbb46a9d1d375e0d23027824de1866f0b13b65
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
   net-http-persistent (4.0.8) sha256=ef3de8319d691537b329053fae3a33195f8b070bbbfae8bf1a58c796081960e6
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
-  oj (3.17.1) sha256=b00687f10bf68a32bfb633b87624174faf0989a5c96aff2f3f96f992717ce782
+  oj (3.17.3) sha256=ebe3967b0bb7ac4f206561d0d9ac8875b9973f778600d7b61b5c355662a707ed
   omni_logger (0.1.4) sha256=b61596f7d96aa8426929e46c3500558d33e838e1afd7f4735244feb4d082bb3e
   ontologies_linked_data (0.0.1)
   ontoportal_testkit (0.1.0)
@@ -642,7 +642,7 @@ CHECKSUMS
   rdf-xsd (3.3.0) sha256=fab51d27b20344237d9b622ef32e83e4c44940840bfc76a245ce6b6abba44772
   readline (0.0.4) sha256=6138eef17be2b98298b672c3ea63bf9cb5158d401324f26e1e84f235879c1d6a
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
-  redis-client (0.29.0) sha256=0c65bf1f8f6dca22063ddb085c0bb2054feef6f03a84869f4161b18a9a15bea3
+  redis-client (0.30.0) sha256=743f11ed42f0a41a0341554087b077479fec7e2d47a7c123fd90a12c0db5e477
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   representable (3.2.0) sha256=cc29bf7eebc31653586849371a43ffe36c60b54b0a6365b5f7d95ec34d1ebace
@@ -656,7 +656,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby-xxHash (0.4.0.2) sha256=201d8305ec1bd0bc32abeaecf7b423755dd1f45f4f4d02ef793b6bb71bf20684
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
-  rubyzip (3.3.1) sha256=2ed92112c7c43ba2b2527f35e6d99d9c2c99270b640aad5227516436481b1e4e
+  rubyzip (3.4.0) sha256=6de39bc9eba302b635a476d16c9e16b0872ad24517c2f98f2b3a7ea23caff57b
   rufus-scheduler (3.9.2) sha256=55fa9e4db0ff69d7f38c804f17baba0c9bce5cba39984ae3c5cf6c039d1323b9
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   signet (0.21.0) sha256=d617e9fbf24928280d39dcfefba9a0372d1c38187ffffd0a9283957a10a8cd5b

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: e1349d0b936dbaee2a9bcebb77198f6e1a50db6b
+  revision: 6bfd79d84b04b38a1a5ae44d241d216bc55a6435
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/ncbo/ontologies_linked_data.git
-  revision: c3a52dfdd0278859a5968b9f5668c5fcd427f854
+  revision: c36ef753ef567d2a4001f83ebc8ff20a4544423d
   branch: develop
   specs:
     ontologies_linked_data (0.0.1)

--- a/lib/ncbo_cron/ontology_rank.rb
+++ b/lib/ncbo_cron/ontology_rank.rb
@@ -48,6 +48,10 @@ module NcboCron
           logger.info('Storing rankings in Redis...')
           redis.set(ONTOLOGY_RANK_REDIS_FIELD, Marshal.dump(ontology_rank))
           logger.info('Rankings successfully stored in Redis')
+
+          logger.info('Propagating rankings to Solr term_search...')
+          updated = LinkedData::Services::RankSolrPropagator.new(logger: logger).propagate
+          logger.info("Propagated rankings to Solr for #{updated} ontologies")
         end
 
         logger.info("Finished generating ontology rankings in #{time.round(3)} seconds")

--- a/test/test_ontology_rank.rb
+++ b/test/test_ontology_rank.rb
@@ -1,0 +1,19 @@
+require_relative 'test_case'
+require 'stringio'
+
+class TestOntologyRankPropagation < TestCase
+  def test_run_propagates_rank_to_solr_after_redis_write
+    rank_job = NcboCron::Models::OntologyRank.new(Logger.new(StringIO.new))
+
+    # Isolate from analytics/UMLS and Redis: stub the computation and the store.
+    rank_job.stubs(:rank_ontologies).returns({ 'BRO' => { bioportalScore: 0.5, umlsScore: 0.0 } })
+    fake_redis = mock('redis')
+    fake_redis.stubs(:set)
+    Redis.stubs(:new).returns(fake_redis)
+
+    # The propagation step must run exactly once.
+    LinkedData::Services::RankSolrPropagator.any_instance.expects(:propagate).once.returns(1)
+
+    rank_job.run
+  end
+end


### PR DESCRIPTION
## Summary

Wires the Solr rank propagation into the existing weekly ontology-rank job. After `NcboCron::Models::OntologyRank#run` recomputes the rank and writes it to Redis, it now calls `LinkedData::Services::RankSolrPropagator` (added in ncbo/ontologies_linked_data#298) to push the current values onto the `ontologyRank` field of every `term_search` class document. Because both `bin/ncbo_ontology_rank_rebuild` and the scheduler thread call `OntologyRank#run`, the propagation runs in both paths with no separate scheduled task.

This keeps the Solr-stored rank within one weekly cycle of the Redis master value, fixing the staleness described in #132 — worst case, a brand-new ontology stuck at rank 0 until its next re-index.

Addresses #132. Depends on ncbo/ontologies_linked_data#298, now merged into `develop`.

## What this does

- `lib/ncbo_cron/ontology_rank.rb`: after the Redis write in `run`, calls `RankSolrPropagator.new(logger: logger).propagate` and logs the number of ontologies updated.
- `test/test_ontology_rank.rb`: stubs the rank computation, Redis, and the propagator, and asserts `run` invokes `propagate` exactly once.